### PR TITLE
generalize usage of GCC-tools

### DIFF
--- a/puncover/collector.py
+++ b/puncover/collector.py
@@ -76,24 +76,6 @@ class Collector:
         self.symbols_by_qualified_name = None
         self.symbols_by_name = None
 
-    def as_dict(self):
-        return {
-            "symbols" : self.symbols,
-            "arm_tools_dir" : self.arm_tools_dir,
-        }
-
-    def save_to_json(self, filename):
-        with open(filename, "w") as f:
-            json.dump(self.as_dict(), f, indent=2, sort_keys=True)
-
-    def from_dict(self, dict):
-        self.symbols = dict.get("symbols", {})
-        self.arm_tools_dir = dict.get("arm_tools_dir", None)
-
-    def load_from_json(self, filename):
-        with open(filename) as f:
-            self.from_dict(json.load(f))
-
     def arm_tool(self, name):
         if not self.arm_tools_dir:
             raise Exception("ARM tools directory not set")
@@ -382,11 +364,6 @@ class Collector:
             print("parsing stack usages starting at %s" % su_dir)
             for l in get_stack_usage_lines(su_dir):
                 self.parse_stack_usage_line(l)
-
-    def parse_pebble_project_dir(self, project_dir):
-        elf_file = os.path.join(project_dir, 'build', 'pebble-app.elf')
-        su_dir = os.path.join(project_dir, "build", "src")
-        self.parse(elf_file, su_dir)
 
     def sorted_by_size(self, symbols):
         return sorted(symbols, key=lambda k: k.get("size", 0), reverse=True)

--- a/puncover/collector.py
+++ b/puncover/collector.py
@@ -1,9 +1,7 @@
 from __future__ import print_function
 import fnmatch
-import json
 import os
 import re
-import subprocess
 import sys
 from __builtin__ import any
 
@@ -63,8 +61,8 @@ def left_strip_from_list(lines):
 
 class Collector:
 
-    def __init__(self, arm_tools_dir=None):
-        self.arm_tools_dir = arm_tools_dir
+    def __init__(self, gcc_tools):
+        self.gcc_tools = gcc_tools
         self.symbols = {}
         self.file_elements = {}
         self.symbols_by_qualified_name = None
@@ -75,16 +73,6 @@ class Collector:
         self.file_elements = {}
         self.symbols_by_qualified_name = None
         self.symbols_by_name = None
-
-    def arm_tool(self, name):
-        if not self.arm_tools_dir:
-            raise Exception("ARM tools directory not set")
-
-        path = os.path.join(self.arm_tools_dir, 'bin', name)
-        if not os.path.isfile(path):
-            raise Exception("Could not find %s" % path)
-
-        return path
 
     def qualified_symbol_name(self, symbol):
         return os.path.join(symbol[PATH], symbol[NAME]) if symbol.has_key(BASE_FILE) else symbol[NAME]
@@ -303,37 +291,20 @@ class Collector:
                     path = path[1:]
                 s[PATH] = path
 
-    # See https://blog.flameeyes.eu/2010/06/c-name-demangling/ for context
-    #
-    # This solution courtesy of:
-    # https://stackoverflow.com/questions/6526500/c-name-mangling-library-for-python/6526814
     def unmangle_cpp_names(self):
         symbol_names = list(symbol[NAME] for symbol in self.all_symbols())
 
-        proc = subprocess.Popen([ self.arm_tool('arm-none-eabi-c++filt') ] + symbol_names, stdout=subprocess.PIPE)
-        demangled = list(s.rstrip() for s in proc.stdout.readlines())
-
-        unmangled_names = dict(zip(symbol_names, demangled))
+        unmangled_names = self.gcc_tools.get_unmangled_names(symbol_names)
 
         for s in self.all_symbols():
             s[DISPLAY_NAME] = unmangled_names[s[NAME]]
 
     def parse_elf(self, elf_file):
-        def get_assembly_lines(elf_file):
-            proc = subprocess.Popen([self.arm_tool('arm-none-eabi-objdump'),'-dslw', os.path.basename(elf_file)], stdout=subprocess.PIPE, cwd=os.path.dirname(elf_file))
-            # proc = subprocess.Popen([in_pebble_sdk('arm-none-eabi-objdump'),'-d', os.path.basename(elf_file)], stdout=subprocess.PIPE, cwd=os.path.dirname(elf_file))
-            return proc.stdout.readlines()
-
-
-        def get_size_lines(elf_file):
-            # http://linux.die.net/man/1/nm
-            proc = subprocess.Popen([self.arm_tool('arm-none-eabi-nm'),'-Sl', os.path.basename(elf_file)], stdout=subprocess.PIPE, cwd=os.path.dirname(elf_file))
-            return proc.stdout.readlines()
 
         print("parsing ELF at %s" % elf_file)
 
-        self.parse_assembly_text("".join(get_assembly_lines(elf_file)))
-        for l in get_size_lines(elf_file):
+        self.parse_assembly_text("".join(self.gcc_tools.get_assembly_lines(elf_file)))
+        for l in self.gcc_tools.get_size_lines(elf_file):
             self.parse_size_line(l)
 
         self.elf_mtime = os.path.getmtime(elf_file)

--- a/puncover/gcc_tools.py
+++ b/puncover/gcc_tools.py
@@ -1,0 +1,39 @@
+import os
+import subprocess
+
+
+class GCCTools:
+    def __init__(self, gcc_base_filename):
+        # if base filename is a directory, make sure we have the trailing slash
+        if os.path.isdir(gcc_base_filename):
+            gcc_base_filename = os.path.join(gcc_base_filename, '')
+
+        self.gcc_base_filename = gcc_base_filename
+
+    def gcc_tool_path(self, name):
+        path = self.gcc_base_filename + name
+        if not os.path.isfile(path):
+            raise Exception("Could not find %s" % path)
+
+        return path
+
+    def gcc_tool_lines(self, name, args, cwd=None):
+        proc = subprocess.Popen([self.gcc_tool_path(name)] + args, stdout=subprocess.PIPE, cwd=cwd)
+        return proc.stdout.readlines()
+
+    def get_assembly_lines(self, elf_file):
+        return self.gcc_tool_lines('objdump', ['-dslw', os.path.basename(elf_file)], os.path.dirname(elf_file))
+
+    def get_size_lines(self, elf_file):
+        # http://linux.die.net/man/1/nm
+        return self.gcc_tool_lines('nm', ['-Sl', os.path.basename(elf_file)], os.path.dirname(elf_file))
+
+    # See https://blog.flameeyes.eu/2010/06/c-name-demangling/ for context
+    #
+    # This solution courtesy of:
+    # https://stackoverflow.com/questions/6526500/c-name-mangling-library-for-python/6526814
+    def get_unmangled_names(self, symbol_names):
+        lines = self.gcc_tool_lines('c++filt', symbol_names)
+        demangled = list(s.rstrip() for s in lines)
+
+        return dict(zip(symbol_names, demangled))

--- a/puncover/puncover.py
+++ b/puncover/puncover.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import argparse
+import os
 from distutils.spawn import find_executable
 from flask import Flask
 from os.path import dirname
@@ -8,10 +9,11 @@ from collector import Collector
 from builders import PebbleProjectBuilder, ElfBuilder
 from middleware import BuilderMiddleware
 import renderers
+from gcc_tools import GCCTools
 
 
-def create_builder(arm_tools_dir, project_dir=None, elf_file=None, su_dir=None, src_root=None):
-    c = Collector(arm_tools_dir=arm_tools_dir)
+def create_builder(gcc_base_filename, project_dir=None, elf_file=None, su_dir=None, src_root=None):
+    c = Collector(GCCTools(gcc_base_filename))
     if project_dir:
         return PebbleProjectBuilder(c, src_root, project_dir)
     elif elf_file:
@@ -30,7 +32,9 @@ def find_arm_tools_location():
 def main():
     parser = argparse.ArgumentParser(description="Pebble build analyzer")
     parser.add_argument('--arm_tools_dir', dest='arm_tools_dir', default=find_arm_tools_location(),
-                        help='location of your arm tools. Typically ~/pebble-dev/PebbleSDK-current/arm-cs-tools')
+                        help='DEPRECATED! location of your arm tools. Typically ~/pebble-dev/PebbleSDK-current/arm-cs-tools')
+    parser.add_argument('--gcc_tools_base', dest='gcc_tools_base',
+                        help='filename prefix for your gcc tools, e.g. ~/arm-cs-tools/bin/arm-none-eabi-')
     parser.add_argument('--elf_file', dest="elf_file",
                         help='location of an ELF file')
     parser.add_argument('--src_root', dest='src_root',
@@ -46,7 +50,13 @@ def main():
     args = parser.parse_args()
     if not args.project_dir and not args.elf_file:
         raise Exception("Specify either a project directory or an ELF file.")
-    builder = create_builder(project_dir=args.project_dir, elf_file=args.elf_file, arm_tools_dir=args.arm_tools_dir,
+
+    if not args.gcc_tools_base:
+        if args.arm_tools_dir:
+            print('DEPRECATED: argument --arm_tools_dir will be removed, use --gcc_tools_base instead.')
+            args.gcc_tools_base = os.path.join(args.arm_tools_dir, 'bin/arm-none-eabi-')
+
+    builder = create_builder(args.gcc_tools_base, project_dir=args.project_dir, elf_file=args.elf_file,
                              src_root=args.src_root, su_dir=args.build_dir)
     builder.build_if_needed()
     renderers.register_jinja_filters(app.jinja_env)

--- a/tests/test_backtrace_helper.py
+++ b/tests/test_backtrace_helper.py
@@ -51,7 +51,7 @@ class TestBacktraceHelper(unittest.TestCase):
 class TestBacktraceHelperTreeSizes(unittest.TestCase):
 
     def setUp(self):
-        self.cc = collector.Collector()
+        self.cc = collector.Collector(None)
         self.a = self.cc.add_symbol("a", "a", type=collector.TYPE_FUNCTION, stack_size=1)
         self.b = self.cc.add_symbol("b", "b", type=collector.TYPE_FUNCTION, stack_size=10)
         self.c = self.cc.add_symbol("c", "c", type=collector.TYPE_FUNCTION, stack_size=100)

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -13,33 +13,31 @@ class TestCollector(unittest.TestCase):
         self.assertEqual(left_strip_from_list(["  a", "   b"]), ["a", " b"])
 
     def test_parses_function_line(self):
-        c = Collector()
+        c = Collector(None)
         line = "00000550 00000034 T main	/Users/behrens/Documents/projects/pebble/puncover/puncover/build/../src/puncover.c:25"
         self.assertTrue(c.parse_size_line(line))
         self.assertDictEqual(c.symbols, {0x00000550: {'name': 'main', 'base_file': 'puncover.c', 'path': '/Users/behrens/Documents/projects/pebble/puncover/puncover/build/../src/puncover.c', 'address': '00000550', 'line': 25, 'size': 52, 'type': 'function'}})
 
     def test_parses_variable_line_from_initialized_data_section(self):
-        c = Collector()
+        c = Collector(None)
         line = "00000968 000000c8 D foo	/Users/behrens/Documents/projects/pebble/puncover/pebble/build/puncover.c:15"
         self.assertTrue(c.parse_size_line(line))
         self.assertDictEqual(c.symbols, {0x00000968: {'name': 'foo', 'base_file': 'puncover.c', 'path': '/Users/behrens/Documents/projects/pebble/puncover/pebble/build/puncover.c', 'address': '00000968', 'line': 15, 'size': 200, 'type': 'variable'}})
 
     def test_parses_variable_line_from_uninitialized_data_section(self):
-        c = Collector()
+        c = Collector(None)
         line = "00000a38 00000008 b some_double_value	/Users/behrens/Documents/projects/pebble/puncover/pebble/build/../src/puncover.c:17"
         self.assertTrue(c.parse_size_line(line))
         self.assertDictEqual(c.symbols, {0x00000a38: {'name': 'some_double_value', 'base_file': 'puncover.c', 'path': '/Users/behrens/Documents/projects/pebble/puncover/pebble/build/../src/puncover.c', 'address': '00000a38', 'line': 17, 'size': 8, 'type': 'variable'}})
 
-
-
     def test_ignores_incomplete_size_line_1(self):
-        c = Collector()
+        c = Collector(None)
         line = "0000059c D __dso_handle"
         self.assertFalse(c.parse_size_line(line))
         self.assertDictEqual(c.symbols, {})
 
     def test_ignores_incomplete_size_line_2(self):
-        c = Collector()
+        c = Collector(None)
         line = "U __preinit_array_end"
         self.assertFalse(c.parse_size_line(line))
         self.assertDictEqual(c.symbols, {})
@@ -54,7 +52,7 @@ pbl_table_addr():
 __aeabi_dmul():
   9c:	b570      	push	{r4, r5, r6, lr}
 """
-        c = Collector()
+        c = Collector(None)
         self.assertEqual(2, c.parse_assembly_text(assembly))
         self.assertTrue(c.symbols.has_key(0x0000009c))
         self.assertEqual(c.symbols[0x0000009c]["name"], "__aeabi_dmul")
@@ -71,7 +69,7 @@ pbl_table_addr():
 __aeabi_dmul():
   9c:	b570      	push	{r4, r5, r6, lr}
 """
-        c = Collector()
+        c = Collector(None)
         self.assertEqual(2, c.parse_assembly_text(assembly))
         self.assertTrue(c.symbols.has_key(0x0000009c))
         self.assertEqual(c.symbols[0x0000009c]["name"], "__aeabi_dmul")
@@ -85,7 +83,7 @@ __aeabi_dmul():
 pbl_table_addr():
   98:	a8a8a8a8 	.word	0xa8a8a8a8
 """
-        c = Collector()
+        c = Collector(None)
         self.assertEqual(1, c.parse_assembly_text(assembly))
         self.assertTrue(c.symbols.has_key(0x00000098))
         self.assertEqual(c.symbols[0x00000098]["name"], "pbl_table_addr")
@@ -113,7 +111,7 @@ $d():
 
 """
 
-        c = Collector()
+        c = Collector(None)
         self.assertEqual(2, c.parse_assembly_text(assembly))
         self.assertTrue(c.symbols.has_key(0x000034fc))
         self.assertEqual(c.symbols[0x000034fc]["name"], "window_raw_click_subscribe")
@@ -127,7 +125,7 @@ $d():
 pbl_table_addr():
  568:	f7ff ffca 	bl	98
 """
-        c = Collector()
+        c = Collector(None)
         self.assertEqual(1, c.parse_assembly_text(assembly))
         self.assertTrue(c.symbols.has_key(0x00000098))
         self.assertEqual(c.symbols[0x00000098]["name"], "pbl_table_addr")
@@ -144,7 +142,7 @@ pbl_table_addr():
 00000930 <app_log>:
 $t():
         """
-        c = Collector()
+        c = Collector(None)
         self.assertEqual(2, c.parse_assembly_text(assembly))
         self.assertTrue(c.symbols.has_key(0x00000098))
         self.assertTrue(c.symbols.has_key(0x00000930))
@@ -166,7 +164,7 @@ $t():
 
 
     def test_enhance_call_tree_from_assembly_line(self):
-        c = Collector()
+        c = Collector(None)
         f1 = "f1"
         f2 = {collector.ADDRESS: "00000088"}
         f3 = {collector.ADDRESS: "00000930"}
@@ -193,7 +191,7 @@ $t():
 
     def test_stack_usage_line(self):
         line = "puncover.c:14:40:0	16	dynamic,bounded"
-        c = Collector()
+        c = Collector(None)
         c.symbols = {"123": {
             "base_file": "puncover.c",
             "line": 14,
@@ -204,7 +202,7 @@ $t():
 
     def test_stack_usage_line2(self):
         line = "puncover.c:8:43:dynamic_stack2	16	dynamic"
-        c = Collector()
+        c = Collector(None)
         c.symbols = {"123": {
             "base_file": "puncover.c",
             "line": 8,
@@ -213,7 +211,7 @@ $t():
 
     def test_stack_usage_line_header(self):
         line = "ILI9341_t3.h:312:15:void ILI9341_t3::updateDisplayClip()	16	static"
-        c = Collector()
+        c = Collector(None)
         c.symbols = {"123": {
             "base_file": "ILI9341_t3.h",
             "line": 312,
@@ -222,7 +220,7 @@ $t():
 
     def test_stack_usage_line_cpp_correct_line(self):
         line = "Print.cpp:34:8:virtual size_t Print::write(const uint8_t*, size_t)	24	static"
-        c = Collector()
+        c = Collector(None)
         c.symbols = {"123": {
             "base_file": "Print.cpp",
             "line": 34,
@@ -233,7 +231,7 @@ $t():
 
     def test_stack_usage_line_cpp_incorrect_line(self):
         line = "Print.cpp:34:8:virtual size_t Print::write(const uint8_t*, size_t)	24	static"
-        c = Collector()
+        c = Collector(None)
         c.symbols = {"123": {
             "base_file": "Print.cpp",
             "display_name": "virtual size_t Print::write(const uint8_t*, size_t)",
@@ -245,7 +243,7 @@ $t():
 
     def test_stack_usage_line_cpp_constructor(self):
         line = "WString.cpp:82:1:String::String(unsigned int, unsigned char)	32	static"
-        c = Collector()
+        c = Collector(None)
         c.symbols = {"123": {
             "base_file": "WString.cpp",
             "line": 82,
@@ -253,7 +251,7 @@ $t():
         self.assertTrue(c.parse_stack_usage_line(line))
 
     def test_display_names_match(self):
-        c = Collector()
+        c = Collector(None)
 
         def f(a, b):
             return c.display_names_match(a, b)
@@ -281,14 +279,14 @@ $t():
 
 
     def test_count_bytes(self):
-        c = Collector()
+        c = Collector(None)
         self.assertEqual(0, c.count_assembly_code_bytes("dynamic_stack2():"))
         self.assertEqual(2, c.count_assembly_code_bytes(" 88e:	4668      	mov	r0, sp"))
         self.assertEqual(4, c.count_assembly_code_bytes(" 88a:	ebad 0d03 	sub.w	sp, sp, r3"))
         self.assertEqual(4, c.count_assembly_code_bytes("878:	000001ba 	.word	0x000001ba"))
 
     def test_enhance_function_size_from_assembly(self):
-        c = Collector()
+        c = Collector(None)
         c.symbols = { int("0000009c", 16) : {
             collector.ADDRESS: "0000009c",
             collector.ASM: """
@@ -305,7 +303,7 @@ $t():
         self.assertEqual(8, s[collector.SIZE])
 
     def test_derive_filename_from_assembly(self):
-        c = Collector()
+        c = Collector(None)
         c.parse_assembly_text("""
 000008a8 <uses_doubles2.constprop.0>:
 uses_doubles2():
@@ -319,7 +317,7 @@ uses_doubles2():
 
 
     def test_enhance_sibling_symbols(self):
-        c = Collector()
+        c = Collector(None)
         aeabi_drsub = {
             collector.ADDRESS: "0000009c",
             collector.SIZE: 8,
@@ -349,7 +347,7 @@ uses_doubles2():
         self.assertFalse(adddf3.has_key(collector.NEXT_FUNCTION))
 
     def test_derive_file_elements(self):
-        c = Collector()
+        c = Collector(None)
         s1 = {collector.PATH: "/Users/behrens/Documents/projects/pebble/puncover/pebble/build/../src/puncover.c"}
         s2 = {collector.PATH: "/Users/thomas/work/arm-eabi-toolchain/build/gcc-final/arm-none-eabi/thumb2/libgcc/../../../../../gcc-4.7-2012.09/libgcc/config/arm/ieee754-df.S"}
         s3 = {collector.PATH: "src/puncover.c"}
@@ -370,7 +368,7 @@ uses_doubles2():
         self.assertIsNotNone(s3[collector.FILE])
 
     def test_derive_file_elements_for_unknown_files(self):
-        c = Collector()
+        c = Collector(None)
         s = c.add_symbol("some_symbol", "00a")
         self.assertEqual("some_symbol", s[collector.NAME])
         self.assertNotIn(collector.PATH, s)
@@ -387,7 +385,7 @@ uses_doubles2():
 
 
     def test_enhance_file_elements(self):
-        c = Collector()
+        c = Collector(None)
         aa_c = c.file_for_path("a/a/aa.c")
         ab_c = c.file_for_path("a/b/ab.c")
         b_c = c.file_for_path("b/b.c")


### PR DESCRIPTION
Introduces ability to point to any GCC-based tools, e.g. `xtensa-lx106-elf-<tool>`, `arm-none-eabi-<tool>` but also host's GCC tools itself.

Today, the assembly analyzation is limited to ARM so that call trees will not be analyzed correctly. Created #7 and #8 to fix this in the future.