### PR TITLE
Only count assembly for size when no size present

### DIFF
--- a/puncover/collector.py
+++ b/puncover/collector.py
@@ -434,7 +434,7 @@ class Collector:
 
     def enhance_function_size_from_assembly(self):
         for f in self.all_symbols():
-            if f.has_key(ASM):
+            if not f.has_key(SIZE) and f.has_key(ASM):
                 f[SIZE] = sum([self.count_assembly_code_bytes(l) for l in f[ASM]])
 
     def enhance_sibling_symbols(self):


### PR DESCRIPTION
Counting assembly bytes doesn't work properly for constant data in the .text section, which causes underreporting of sizes. The actual size reported by nm is present and accurate, so we prefer that and only count assembly bytes when nm doesn't give us a size.