### PR TITLE
Adds a host command line parameter

### DIFF
--- a/puncover/puncover.py
+++ b/puncover/puncover.py
@@ -45,6 +45,8 @@ def main():
                         help='enable Flask debugger')
     parser.add_argument('--port', dest='port', default=5000, type=int,
                         help='port the HTTP server runs on')
+    parser.add_argument('--host', dest='host', default='127.0.0.1',
+                        help='host IP the HTTP server runs on')
     args = parser.parse_args()
 
     if not args.gcc_tools_base:
@@ -61,7 +63,7 @@ def main():
 
     if args.debug:
         app.debug = True
-    app.run(port=args.port)
+    app.run(host=args.host, port=args.port)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hi, I'm using a headless Vagrant box for my embedded toolchains on several of my projects.  I want to run Puncover from that VM and use the web UI from a browser on the VM host.  In order to do that, I need to serve it to an externally visible IP (not localhost).

I added a command line parameter that allows you to specify a different IP, but has a default of `localhost` so if you don't need this parameter Puncover still works like it did before.

Usually I'd try to get some buy in before opening a PR, but seeing as the whole modification is just 3 lines I figured it'd be easier to just put in the PR so we could discuss the exact changes.