### PR TITLE
Add Tox and TravisCI test matrix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /puncover.egg-info/
 /build/
 /dist/
+.tox
+.coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: python
 python:
+  # Python3.5 unit tests fail
+  - "3.6"
   - "3.7"
-install:
-  - pip install .
-  - pip install -r requirements.txt
-  - python setup.py -q install
-script:
-  - nosetests --with-cov
+  - "3.8"
+install: pip install tox-travis
+script: tox
 after_success:
   - codecov

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
+include requirements-test.txt
 include puncover/static/**/*
 include puncover/templates/**

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,4 @@
+nose
+codecov
+nose-cov
+mock

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-Flask==0.10.1
-mock==1.3.0
-codecov==2.0.5
-nose-cov==1.6

--- a/setup.py
+++ b/setup.py
@@ -4,15 +4,13 @@ import os
 from setuptools import setup, find_packages, Command
 
 __version__ = None  # Overwritten by executing version.py.
-with open('puncover/version.py') as f:
-    exec (f.read())
-
-with open('requirements.txt') as f:
-    requires = f.readlines()
+with open("puncover/version.py") as f:
+    exec(f.read())
 
 
 class CleanCommand(Command):
     """Custom clean command to tidy up the project root."""
+
     # http://stackoverflow.com/a/3780822/196350
     user_options = []
 
@@ -23,24 +21,23 @@ class CleanCommand(Command):
         pass
 
     def run(self):
-        os.system('rm -vrf ./build ./dist ./*.pyc ./*.tgz ./*.egg-info')
+        os.system("rm -vrf ./build ./dist ./*.pyc ./*.tgz ./*.egg-info")
 
 
-setup(name='puncover',
-      version=__version__,
-      description='Analyses C/C++ build output for code size, static variables, and stack usage.',
-      long_description=open('README.rst').read(),
-      url='https://github.com/hbehrens/puncover',
-      download_url='https://github.com/hbehrens/puncover/tarball/%s' % __version__,
-      author='Heiko Behrens',
-      license='MIT',
-      packages=find_packages(exclude=['tests', 'tests.*']),
-      include_package_data=True,
-      zip_safe=False,
-      entry_points={'console_scripts': ['puncover = puncover.puncover:main']},
-      install_requires=requires,
-      test_suite='nose.collector',
-      cmdclass={
-          'clean': CleanCommand,
-      }
-      )
+setup(
+    name="puncover",
+    version=__version__,
+    description="Analyses C/C++ build output for code size, static variables, and stack usage.",
+    long_description=open("README.rst").read(),
+    url="https://github.com/hbehrens/puncover",
+    download_url="https://github.com/hbehrens/puncover/tarball/%s" % __version__,
+    author="Heiko Behrens",
+    license="MIT",
+    packages=find_packages(exclude=["tests", "tests.*"]),
+    include_package_data=True,
+    zip_safe=False,
+    entry_points={"console_scripts": ["puncover = puncover.puncover:main"]},
+    install_requires=["Flask==0.10.1", "mock==1.3.0", "codecov==2.0.5", "nose-cov==1.6"],
+    test_suite="nose.collector",
+    cmdclass={"clean": CleanCommand,},
+)

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,10 @@ with open("puncover/version.py") as f:
     exec(f.read())
 
 
+with open('requirements-test.txt') as f:
+    tests_require = f.readlines()
+
+
 class CleanCommand(Command):
     """Custom clean command to tidy up the project root."""
 
@@ -37,7 +41,8 @@ setup(
     include_package_data=True,
     zip_safe=False,
     entry_points={"console_scripts": ["puncover = puncover.puncover:main"]},
-    install_requires=["Flask==0.10.1", "mock==1.3.0", "codecov==2.0.5", "nose-cov==1.6"],
+    install_requires=["Flask==0.10.1"],
+    tests_require=tests_require,
     test_suite="nose.collector",
     cmdclass={"clean": CleanCommand,},
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+# Python3.5 unit tests fail
+envlist = py{36,37,38}
+
+[testenv]
+deps = 
+    nose
+commands = nosetests --with-cov

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,5 @@
 envlist = py{36,37,38}
 
 [testenv]
-deps = 
-    nose
+deps = -rrequirements-test.txt
 commands = nosetests --with-cov


### PR DESCRIPTION
Summary:
The way I've done build matrices in the past is to use Tox to handle all
the tedious work of setting up virtul aenvironments and running the
tests.

It also looks like there's a nice plugin,
[tox-travis](https://github.com/tox-dev/tox-travis), which takes in the
evironment definsed to run the appropriate tests.

Unfortunately, when this was run against Pythonn 3.5, the tests failed,
so that's a later PR.

Test Plan:
- Run `tox` locally and confirm the tests pass on py36, py37, and py38