### PR TITLE
Fix for .su files containing full file path instead of basename

### DIFF
--- a/puncover/collector.py
+++ b/puncover/collector.py
@@ -196,7 +196,7 @@ class Collector:
         if not match:
             return False
 
-        base_file_name = match.group(1)
+        base_file_name = os.path.basename(match.group(1)) # Seems this can sometimes be the complete file name instead of base_file_name
         line = int(match.group(3))
         symbol_name = match.group(5)
         stack_size = int(match.group(6))

--- a/puncover/renderers.py
+++ b/puncover/renderers.py
@@ -1,4 +1,4 @@
-from collections import Iterable
+from collections.abc import Iterable
 import os
 import re
 from flask import Flask, render_template, abort, redirect, request


### PR DESCRIPTION
While using puncover on my Zephyr build, I couldn't get the stack usage to work anymore.
Worst-case stack is one of my favorite features of puncover.

I turned out this was cause by `parse_stack_usage_line` not being able to match the `.su` file contents to the symbols currently loaded in puncover's `self.symbols`. Since `add_stack_usage` is looking to match on `base_file_name`, this would file for an '.su' file like this one:
```
/home/user/path/to/zephyr/lib/os/heap.c:11:14:chunk_mem	0	static
/home/user/path/to/zephyr/lib/os/heap.c:21:13:free_list_remove_bidx	4	static
/home/user/path/to/zephyr/lib/os/heap.c:51:13:free_list_add_bidx	8	static
/home/user/path/to/zephyr/lib/os/heap.c:88:13:split_chunks	8	static
/home/user/path/to/zephyr/lib/os/heap.c:104:13:merge_chunks	8	static
/home/user/path/to/zephyr/lib/os/heap.c:136:18:mem_to_chunkid	0	static
/home/user/path/to/zephyr/lib/os/heap.c:43:13:free_list_remove	8	static
/home/user/path/to/zephyr/lib/os/heap.c:77:13:free_list_add	8	static
/home/user/path/to/zephyr/lib/os/heap.c:112:13:free_chunk	24	static
/home/user/path/to/zephyr/lib/os/heap.c:170:18:alloc_chunk	24	static
/home/user/path/to/zephyr/lib/os/heap.c:142:6:sys_heap_free	8	static
/home/user/path/to/zephyr/lib/os/heap.c:222:7:sys_heap_alloc	16	static
/home/user/path/to/zephyr/lib/os/heap.c:246:7:sys_heap_aligned_alloc	24	static
/home/user/path/to/zephyr/lib/os/heap.c:313:7:sys_heap_aligned_realloc	56	static
/home/user/path/to/zephyr/lib/os/heap.c:380:6:sys_heap_init	24	static
```
