### PR TITLE
Stop depending on ancient Flask version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
-Flask==0.10.1
+Flask>=2.0.0
+werkzeug==2.0.3
+Jinja2==3.0.3
 mock==1.3.0
 codecov==2.0.5
 nose-cov==1.6


### PR DESCRIPTION
This patch tries to solve the same problem as https://github.com/HBehrens/puncover/pull/47 - but instead of keeping the ancient Flask 0.10.1 from 9 years ago and pinning all transitive dependencies, it accepts newer versions of Flask, and only pins the versions of werkzeug and Jinja2 (used by puncover directly) to versions just before they changed the API too much.

It works like this on my Ubuntu 20.04 / Python 3.8.10 system.
