### PR TITLE
Support python3.10

### DIFF
--- a/puncover/renderers.py
+++ b/puncover/renderers.py
@@ -1,16 +1,22 @@
-from collections import Iterable
-import os
-import re
-from flask import Flask, render_template, abort, redirect, request
-from flask.helpers import url_for
-from flask.views import View
+
+# Python3.10 moved this module, support both import paths
+try:
+    from collections import Iterable
+except ImportError:
+    from collections.abc import Iterable
+
 import itertools
+import re
+
 import jinja2
 import markupsafe
+from flask import abort, redirect, render_template, request
+from flask.helpers import url_for
+from flask.views import View
 from werkzeug.urls import Href
 
-from puncover.backtrace_helper import BacktraceHelper
 from puncover import collector
+from puncover.backtrace_helper import BacktraceHelper
 
 KEY_OUTPUT_FILE_NAME = "output_file_name"
 
@@ -25,7 +31,7 @@ def renderer_from_context(context):
 def symbol_file(value):
     return value.get(collector.BASE_FILE, '__builtin')
 
-@jinja2.contextfilter
+@jinja2.pass_context
 def symbol_url_filter(context, value):
     renderer = renderer_from_context(context)
     if renderer:
@@ -33,7 +39,7 @@ def symbol_url_filter(context, value):
 
     return None
 
-@jinja2.contextfilter
+@jinja2.pass_context
 def symbol_file_url_filter(context, value):
     f = value.get(collector.FILE, None)
     return symbol_url_filter(context, f) if f else None
@@ -63,26 +69,26 @@ def traverse_filter_wrapper(value, func):
     result = symbol_traverse(value, func)
     return result if result != 0 else ""
 
-@jinja2.contextfilter
+@jinja2.pass_context
 def symbol_code_size_filter(context, value):
     return traverse_filter_wrapper(value, lambda s: s.get(collector.SIZE, None) if s.get(collector.TYPE, None) == collector.TYPE_FUNCTION else 0)
 
-@jinja2.contextfilter
+@jinja2.pass_context
 def symbol_var_size_filter(context, value):
     return traverse_filter_wrapper(value, lambda s: s.get(collector.SIZE, None) if s.get(collector.TYPE, None) == collector.TYPE_VARIABLE else 0)
 
-@jinja2.contextfilter
+@jinja2.pass_context
 def symbol_stack_size_filter(context, value, stack_base=None):
     if isinstance(stack_base, str):
         stack_base = None
     result = traverse_filter_wrapper(value, lambda s: s.get(collector.STACK_SIZE, None) if s.get(collector.TYPE, None) == collector.TYPE_FUNCTION else None)
     return none_sum(result, stack_base)
 
-@jinja2.contextfilter
+@jinja2.pass_context
 def if_not_none_filter(context, value, default_value=""):
     return value if value is not None else default_value
 
-@jinja2.contextfilter
+@jinja2.pass_context
 def unique_filter(context, value):
     if isinstance(value, Iterable):
         result = []
@@ -94,7 +100,7 @@ def unique_filter(context, value):
     return value
 
 
-@jinja2.contextfilter
+@jinja2.pass_context
 def assembly_filter(context, value):
     renderer = context.parent.get("renderer", None)
     def linked_symbol_name(name):
@@ -133,7 +139,7 @@ def assembly_filter(context, value):
     return s
     # return str("&lt;")
 
-@jinja2.contextfilter
+@jinja2.pass_context
 def symbols_filter(context, value):
     renderer = renderer_from_context(context)
 
@@ -151,7 +157,7 @@ def symbols_filter(context, value):
 
     return value
 
-@jinja2.contextfilter
+@jinja2.pass_context
 def chain_filter(context, value, second_value=None):
     return list(itertools.chain(value, second_value if second_value else []))
 
@@ -160,7 +166,7 @@ def is_int_ge(x, cmp):
     return isinstance(x, int) and x >= cmp
 
 
-@jinja2.contextfilter
+@jinja2.pass_context
 def bytes_filter(context, x):
     if not is_int_ge(x, 0):
         return x
@@ -172,7 +178,7 @@ def bytes_filter(context, x):
     return "%d%s" % (x, result)
 
 
-@jinja2.contextfilter
+@jinja2.pass_context
 def style_background_bar_filter(context, x, total, color=None):
     if not is_int_ge(x, 1) or not is_int_ge(total, 1):
         return ''
@@ -184,7 +190,7 @@ def style_background_bar_filter(context, x, total, color=None):
     percent = 100 * x // total
     return 'background:linear-gradient(90deg, {1} {0}%, transparent {0}%);'.format(percent, color)
 
-@jinja2.contextfilter
+@jinja2.pass_context
 def col_sortable_filter(context, title, is_alpha=False, id=None):
 
     id = title if id is None else id
@@ -211,7 +217,7 @@ def col_sortable_filter(context, title, is_alpha=False, id=None):
     return '<a href="%s" class="%s">%s</a>' % (url(args), ' '.join(classes), title)
 
 
-@jinja2.contextfilter
+@jinja2.pass_context
 def sorted_filter(context, symbols):
     sort_id, sort_order = context.parent['sort'].split('_')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
-Flask==0.10.1
-mock==1.3.0
-codecov==2.0.5
+codecov==2.1.12
+Flask==2.1.2
+jinja2==3
+mock==4.0.3
 nose-cov==1.6
+werkzeug==2.0.2


### PR DESCRIPTION
Similar to #48 (and #47), update `requirements.txt` with
compatible `werkzeug` dependency. Update to a more recent Flask version
and fix a compatibility error with the new jinja2 transitive dependency.

Also pin `jinja2` to major version, just in case.

And finally, add a small compatibility patch to support python3.10.

Tested on python3.10 and python3.9 virtualenvs.