### PR TITLE
Add support for 64-bit addresses

### DIFF
--- a/puncover/collector.py
+++ b/puncover/collector.py
@@ -118,7 +118,7 @@ class Collector:
         return sym
 
     # 00000550 00000034 T main	/Users/behrens/Documents/projects/pebble/puncover/puncover/build/../src/puncover.c:25
-    parse_size_line_re = re.compile(r"^([\da-f]{8})\s+([\da-f]{8})\s+(.)\s+(\w+)(\s+([^:]+):(\d+))?")
+    parse_size_line_re = re.compile(r"^([\da-f]{8,16})\s+([\da-f]{8,16})\s+(.)\s+(\w+)(\s+([^:]+):(\d+))?")
 
     def parse_size_line(self, line):
         # print(line)
@@ -145,7 +145,7 @@ class Collector:
 
     # 00000098 <pbl_table_addr>:
     # 00000098 <pbl_table_addr.constprop.0>:
-    parse_assembly_text_function_start_pattern = re.compile(r"^([\da-f]{8})\s+<(\.?\w+)(\..*)?>:")
+    parse_assembly_text_function_start_pattern = re.compile(r"^([\da-f]{8,16})\s+<(\.?\w+)(\..*)?>:")
 
     # /Users/behrens/Documents/projects/pebble/puncover/pebble/build/../src/puncover.c:8
     parse_assembly_text_c_reference_pattern = re.compile(r"^(/[^:]+)(:(\d+))?")


### PR DESCRIPTION
The regex in collector.py currently assumes that the memory addresses output by nm are 8-characters wide (e.g. 32-bit addresses). Update the regex to accept any number of characters between 8 and 16 (to support 64-bit addresses).

Minimal test example using a 64-bit host machine and toolchain (shows no symbols on current master, but finds symbols on this commit):

```
echo "int main() { return 0; }" > test.cpp
g++ test.cpp   # uses host gcc tools (64-bit Linux) but same result for AARCH64 compilers
puncover --gcc_tools_base /usr/bin/ --elf ./a.out --src_root . --build_dir .
```

I'm not sure whether the regexes to parse assembly lines will also need updating in the future; the platform I'm working on does not have any disassembly wider than 9 characters. I did update the assembly *addresses*, though, and also added test cases for both address types.