### PR TITLE
Replicate of #38 changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 **/.idea/
 *.pyc
-/puncover.egg-info/
+*.egg-info/
 /build/
 /dist/
+.tox
+.coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: python
 python:
+  # Python3.5 unit tests fail
+  - "3.6"
   - "3.7"
-install:
-  - pip install .
-  - pip install -r requirements.txt
-  - python setup.py -q install
-script:
-  - nosetests --with-cov
+  - "3.8"
+install: pip install tox-travis
+script: tox
 after_success:
   - codecov

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
+include requirements-test.txt
 include puncover/static/**/*
 include puncover/templates/**

--- a/puncover/version.py
+++ b/puncover/version.py
@@ -1,2 +1,2 @@
-__version_info__ = (0, 0, 1)
+__version_info__ = (0, 1, 0)
 __version__ = '.'.join(map(str, __version_info__))

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,4 @@
+nose
+codecov
+nose-cov
+mock

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,0 @@
-codecov==2.1.12
-Flask==2.1.2
-jinja2==3
-mock==4.0.3
-nose-cov==1.6
-werkzeug==2.0.2

--- a/setup.py
+++ b/setup.py
@@ -4,15 +4,17 @@ import os
 from setuptools import setup, find_packages, Command
 
 __version__ = None  # Overwritten by executing version.py.
-with open('puncover/version.py') as f:
-    exec (f.read())
+with open("puncover/version.py") as f:
+    exec(f.read())
 
-with open('requirements.txt') as f:
-    requires = f.readlines()
+
+with open('requirements-test.txt') as f:
+    tests_require = f.readlines()
 
 
 class CleanCommand(Command):
     """Custom clean command to tidy up the project root."""
+
     # http://stackoverflow.com/a/3780822/196350
     user_options = []
 
@@ -23,24 +25,39 @@ class CleanCommand(Command):
         pass
 
     def run(self):
-        os.system('rm -vrf ./build ./dist ./*.pyc ./*.tgz ./*.egg-info')
+        os.system("rm -vrf ./build ./dist ./*.pyc ./*.tgz ./*.egg-info")
 
 
-setup(name='puncover',
-      version=__version__,
-      description='Analyses C/C++ build output for code size, static variables, and stack usage.',
-      long_description=open('README.rst').read(),
-      url='https://github.com/hbehrens/puncover',
-      download_url='https://github.com/hbehrens/puncover/tarball/%s' % __version__,
-      author='Heiko Behrens',
-      license='MIT',
-      packages=find_packages(exclude=['tests', 'tests.*']),
-      include_package_data=True,
-      zip_safe=False,
-      entry_points={'console_scripts': ['puncover = puncover.puncover:main']},
-      install_requires=requires,
-      test_suite='nose.collector',
-      cmdclass={
-          'clean': CleanCommand,
-      }
-      )
+setup(
+    name="puncover",
+    version=__version__,
+    description="Analyses C/C++ build output for code size, static variables, and stack usage.",
+    long_description=open("README.rst").read(),
+    long_description_content_type="text/x-rst",
+    url="https://github.com/hbehrens/puncover",
+    download_url="https://github.com/hbehrens/puncover/tarball/%s" % __version__,
+    author="Heiko Behrens",
+    license="MIT",
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Developers",
+        "Natural Language :: English",
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+    ],
+    packages=find_packages(exclude=["tests", "tests.*"]),
+    include_package_data=True,
+    zip_safe=False,
+    entry_points={"console_scripts": ["puncover = puncover.puncover:main"]},
+    install_requires=["Flask==0.10.1"],
+    tests_require=tests_require,
+    test_suite="nose.collector",
+    cmdclass={"clean": CleanCommand,},
+    # TODO: https://github.com/HBehrens/puncover/issues/36
+    #  Fix Python 3.5
+    python_requires=">=3.6",
+)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,7 @@
+[tox]
+# Python3.5 unit tests fail
+envlist = py{36,37,38}
+
+[testenv]
+deps = -rrequirements-test.txt
+commands = nosetests --with-cov


### PR DESCRIPTION
---

Setup Tox and Travis Build Matrix

Summary:
The way I've done build matrices in the past is to use Tox to handle all
the tedious work of setting up virtul aenvironments and running the
tests.

It also looks like there's a nice plugin,
[tox-travis](https://github.com/tox-dev/tox-travis), which takes in the
evironment definsed to run the appropriate tests.

Unfortunately, when this was run against Pythonn 3.5, the tests failed,
so that's a later PR.

Test Plan:
- Run `tox` locally and confirm the tests pass on py36, py37, and py38

---

Add back a requirements-test.txt file

Need this to get codecov command working again

---

Prep for PyPi upload

Summary:
- Set the version to 0.1.0
- Add proper PyPi classifiers
- Require the correct Python versions until the Python 3.5 bug is fixed

Test Plan:
- I uploaded the package to test.pypi.org under a different name and I
have confirm that I can install the package and use it under a fresh Conda
environment
- Run tox locally to confirm 3.6-3.8 works
