### PR TITLE
Fix stack usage parsing of base file name

### DIFF
--- a/puncover/collector.py
+++ b/puncover/collector.py
@@ -196,7 +196,8 @@ class Collector:
         if not match:
             return False
 
-        base_file_name = match.group(1)
+        file = match.group(1)
+        base_file_name = os.path.basename(file)
         line = int(match.group(3))
         symbol_name = match.group(5)
         stack_size = int(match.group(6))


### PR DESCRIPTION
The base file name was not parsed correctly. Instead the file was assigned as a [base file name](https://github.com/HBehrens/puncover/blob/ec63f21c8be12fef2724beb28810d0b7238640f9/puncover/collector.py#L199). This caused the function `add_stack_usage ` to not find the file name obtained from the .su file and the .elf file as they were not the same.

Fixes https://github.com/HBehrens/puncover/issues/62