### PR TITLE
Add actions run on PR, and mac

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,16 +1,32 @@
 name: Python package
 
-on: [push]
+on:
+  push:
+    branches: [master]
+
+  pull_request:
+    branches: [master]
+
+  workflow_dispatch:
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         # note: 3.5 + 3.6 are EOL as of 2022-09-16. tests do fail on python3.5,
         # see https://github.com/HBehrens/puncover/issues/36
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        # it's convenient to stay on an older ubuntu as long as we need
+        # python3.6:
+        # https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
+        os: [
+            ubuntu-20.04,
+            macos-12,
+            # windows is disabled until path support works there
+            # windows-2022,
+          ]
+      fail-fast: false
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Previously actions was only running on pushes. Tidy that up and make it
run on PR's as well.

Run tests on mac as well- added a windows run to the matrix, but it
fails due to path mismatch issues, which are addressed in other PRs, so
leaving it disabled here.