### PR TITLE
noahp/vChavezB/windows port

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,7 @@ jobs:
         os: [
             ubuntu-20.04,
             macos-12,
-            # windows is disabled until path support works there
-            # windows-2022,
+            windows-2022,
           ]
       fail-fast: false
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2014-2017 Heiko Behrens
+Copyright (c) 2022 Victor Chavez
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/puncover/builders.py
+++ b/puncover/builders.py
@@ -2,7 +2,7 @@ import abc
 import os
 from os.path import dirname
 from puncover.backtrace_helper import BacktraceHelper
-
+import pathlib
 
 class Builder:
 
@@ -10,7 +10,7 @@ class Builder:
         self.files = {}
         self.collector = collector
         self.backtrace_helper = BacktraceHelper(collector)
-        self.src_root = src_root
+        self.src_root = pathlib.Path(src_root)
 
     def store_file_time(self, path, store_empty=False):
         self.files[path] = 0 if store_empty else os.path.getmtime(path)

--- a/puncover/collector.py
+++ b/puncover/collector.py
@@ -201,8 +201,8 @@ class Collector:
         if not match:
             return False
 
-        file = match.group(1)
-        base_file_name = os.path.basename(file)
+        file = pathlib.Path(match.group(1))
+        base_file_name = pathlib.Path(file.name)
         line = int(match.group(3))
         symbol_name = match.group(5)
         stack_size = int(match.group(6))

--- a/puncover/collector.py
+++ b/puncover/collector.py
@@ -2,6 +2,7 @@ import fnmatch
 import os
 import re
 import sys
+import pathlib
 
 NAME = "name"
 DISPLAY_NAME = "display_name"
@@ -74,12 +75,12 @@ class Collector:
 
     def qualified_symbol_name(self, symbol):
         if BASE_FILE in symbol:
-            return os.path.join(symbol[PATH], symbol[NAME])
+            html_path = pathlib.Path.joinpath(symbol[PATH], symbol[NAME])
+            return str(html_path)
         return symbol[NAME]
 
     def symbol(self, name, qualified=True):
         self.build_symbol_name_index()
-
         index = self.symbols_by_qualified_name if qualified else self.symbols_by_name
         return index.get(name, None)
 
@@ -98,8 +99,8 @@ class Collector:
         if size:
             sym[SIZE] = int(size)
         if file:
-            sym[PATH] = file
-            sym[BASE_FILE] = os.path.basename(file)
+            sym[PATH] = pathlib.Path(file)
+            sym[BASE_FILE] = sym[PATH].name
         if line:
             sym[LINE] = line
         if assembly_lines:
@@ -118,7 +119,11 @@ class Collector:
         return sym
 
     # 00000550 00000034 T main	/Users/behrens/Documents/projects/pebble/puncover/puncover/build/../src/puncover.c:25
-    parse_size_line_re = re.compile(r"^([\da-f]{8})\s+([\da-f]{8})\s+(.)\s+(\w+)(\s+([^:]+):(\d+))?")
+    if os.name == 'nt':
+        parse_size_line_re = re.compile(r"^([\da-f]{8})\s+([\da-f]{8})\s+(.)\s+(\w+)(\s+([a-zA-Z]:.+)):(\d+)?")
+    else:
+        parse_size_line_re = re.compile(r"^([\da-f]{8})\s+([\da-f]{8})\s+(.)\s+(\w+)(\s+([^:]+):(\d+))?")
+
 
     def parse_size_line(self, line):
         # print(line)
@@ -196,7 +201,8 @@ class Collector:
         if not match:
             return False
 
-        base_file_name = match.group(1)
+        file = match.group(1)
+        base_file_name = os.path.basename(file)
         line = int(match.group(3))
         symbol_name = match.group(5)
         stack_size = int(match.group(6))
@@ -278,17 +284,28 @@ class Collector:
         # warning("Couldn't find symbol for %s:%d:%s" % (base_file_name, line, symbol_name))
         return False
 
-
+    windows_path_pattern = re.compile(r"^([a-zA-Z]+)(:)(\\)(.+)$")
+    
     def normalize_files_paths(self, base_dir):
-        base_dir = os.path.abspath(base_dir) if base_dir else "/"
-
+        base_dir = os.path.abspath(base_dir) if base_dir else pathlib.Path(".")
         for s in self.all_symbols():
             path = s.get(PATH, None)
             if path:
-                if path.startswith(base_dir):
-                    path = os.path.relpath(path, base_dir)
-                elif path.startswith("/"):
-                    path = path[1:]
+                str_path = str(path)
+                abs_win_path = self.windows_path_pattern.match(str_path)
+                if base_dir in path.parents:
+                    path = path.relative_to(base_dir)
+                # Remove root from path
+                elif str_path.startswith("/"):
+                    str_path = str_path[1:]
+                    path = pathlib.Path(str_path)
+                elif abs_win_path:
+                    # prefix drive letter 
+                    # in the rare case where there are two
+                    # files with same path and different drive letter
+                    drive_letter = abs_win_path.group(1)
+                    str_path = abs_win_path.group(1)+"_"+abs_win_path.group(4)
+                    path = pathlib.Path(str_path)
                 s[PATH] = path
 
     def unmangle_cpp_names(self):
@@ -452,12 +469,21 @@ class Collector:
 
     def derive_folders(self):
         for s in self.all_symbols():
-            p = s.get(PATH, "<unknown>/<unknown>")
-            p = os.path.normpath(p)
+            p = s.get(PATH, pathlib.Path("<unknown>/<unknown>"))
+            resolved_path = p.resolve(strict=False)
+            if not p.is_absolute():
+                # pathlib prepends cwd if it couldnt 
+            	# resolve locally the file
+                cwd = pathlib.Path().absolute()
+                # remove cwd as it is not part of the relative path
+                p = resolved_path.relative_to(cwd)
+            else:
+                p = resolved_path
             s[PATH] = p
-            s[BASE_FILE] = os.path.basename(p)
+            s[BASE_FILE] = pathlib.Path(p.name)
             s[FILE] = self.file_for_path(p)
             s[FILE][SYMBOLS].append(s)
+
 
     def file_element_for_path(self, path, type, default_values):
         if not path:
@@ -465,8 +491,13 @@ class Collector:
 
         result = self.file_elements.get(path, None)
         if not result:
-            parent_dir = os.path.dirname(path)
-            parent_folder = self.folder_for_path(parent_dir) if parent_dir and parent_dir != "/" else None
+            parent_len = len(path.parents)
+            if parent_len > 0:
+                parent_dir = path.parents[0]
+            else:
+                parent_dir = path
+            parent_available = parent_len > 0 and parent_dir != pathlib.Path(".")
+            parent_folder = self.folder_for_path(parent_dir) if parent_available else None 
             result = {
                 TYPE: type,
                 PATH: path,

--- a/puncover/gcc_tools.py
+++ b/puncover/gcc_tools.py
@@ -14,6 +14,8 @@ class GCCTools:
 
     def gcc_tool_path(self, name):
         path = self.gcc_base_filename + name
+        if os.name == 'nt':
+            path+=".exe"
         if not os.path.isfile(path):
             raise Exception("Could not find %s" % path)
 

--- a/puncover/renderers.py
+++ b/puncover/renderers.py
@@ -7,6 +7,7 @@ except ImportError:
 
 import itertools
 import re
+import pathlib
 
 import jinja2
 import markupsafe
@@ -296,12 +297,14 @@ class PathRenderer(HTMLRenderer):
         if path.endswith("/"):
             path = path[:-1]
 
+        generic_path = pathlib.Path(path)
         symbol = self.collector.symbol(path)
+
         if symbol:
             self.template_vars["symbol"] = symbol
             return self.render_template("symbol.html.jinja", "symbol")
 
-        file_element = self.collector.file_elements.get(path, None)
+        file_element = self.collector.file_elements.get(generic_path, None)
         if file_element and file_element[collector.TYPE] == collector.TYPE_FILE:
             self.template_vars["file"] = file_element
             return self.render_template("file.html.jinja", path)

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
     url="https://github.com/hbehrens/puncover",
     download_url="https://github.com/hbehrens/puncover/tarball/%s" % __version__,
     author="Heiko Behrens",
+    maintainer="Victor Chavez",
     license="MIT",
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
- Add actions run on PR, and mac
- - Added interoperability between Windows and Linux paths with pathlib - Changed tests for Collector class with pathlib. - Added copyright and mantainer info for further contact of the changes of this commit.
- fixed base file initialization of a pathlib type for stack usage
