### PR TITLE
Pathlib port (Windows/Linux/MacOS)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,7 @@ jobs:
         os: [
             ubuntu-20.04,
             macos-12,
-            # windows is disabled until path support works there
-            # windows-2022,
+            windows-2022
           ]
       fail-fast: false
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2014-2017 Heiko Behrens
+Copyright (c) 2022 Victor Chavez
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/puncover/builders.py
+++ b/puncover/builders.py
@@ -50,7 +50,7 @@ class ElfBuilder(Builder):
     def __init__(self, collector, src_root, elf_file, su_dir):
         Builder.__init__(self, collector, src_root if src_root else dirname(dirname(elf_file)))
         self.store_file_time(elf_file, store_empty=True)
-        self.elf_file = elf_file
+        self.elf_file = pathlib.Path(elf_file)
         self.su_dir = su_dir
 
     def get_elf_path(self):

--- a/puncover/builders.py
+++ b/puncover/builders.py
@@ -2,7 +2,7 @@ import abc
 import os
 from os.path import dirname
 from puncover.backtrace_helper import BacktraceHelper
-
+import pathlib
 
 class Builder:
 
@@ -10,7 +10,7 @@ class Builder:
         self.files = {}
         self.collector = collector
         self.backtrace_helper = BacktraceHelper(collector)
-        self.src_root = src_root
+        self.src_root = pathlib.Path(src_root)
 
     def store_file_time(self, path, store_empty=False):
         self.files[path] = 0 if store_empty else os.path.getmtime(path)

--- a/puncover/collector.py
+++ b/puncover/collector.py
@@ -201,8 +201,8 @@ class Collector:
         if not match:
             return False
 
-        file = match.group(1)
-        base_file_name = os.path.basename(file)
+        file = pathlib.Path(match.group(1))
+        base_file_name = pathlib.Path(file.name)
         line = int(match.group(3))
         symbol_name = match.group(5)
         stack_size = int(match.group(6))

--- a/puncover/collector.py
+++ b/puncover/collector.py
@@ -202,7 +202,7 @@ class Collector:
             return False
 
         file = pathlib.Path(match.group(1))
-        base_file_name = pathlib.Path(file.name)
+        base_file_name = file.name
         line = int(match.group(3))
         symbol_name = match.group(5)
         stack_size = int(match.group(6))

--- a/puncover/collector.py
+++ b/puncover/collector.py
@@ -475,13 +475,14 @@ class Collector:
             p = s.get(PATH, unknown_path)
             if p != unknown_path:
                 posix_root_path = str(p).startswith("\\")
+                windows_os = os.name == "nt"
                 # Detects if parsing posix paths in elf in a windows machine
-                win_parsing_posix = (os.name == "nt" and posix_root_path) 
+                win_parsing_posix = windows_os and posix_root_path
                 if not win_parsing_posix:
                     resolved_path = p.resolve(strict=False)
                 else:
                     resolved_path = p
-                cwd_prepend_to_path = PYTHON_VER["major"]==3 and PYTHON_VER["minor"]>9
+                cwd_prepend_to_path = PYTHON_VER["major"]==3 and PYTHON_VER["minor"]>9 and windows_os
                 if (not p.is_absolute() 
                     and not win_parsing_posix
                     and cwd_prepend_to_path): 

--- a/puncover/collector.py
+++ b/puncover/collector.py
@@ -2,6 +2,7 @@ import fnmatch
 import os
 import re
 import sys
+import pathlib
 
 NAME = "name"
 DISPLAY_NAME = "display_name"
@@ -74,12 +75,12 @@ class Collector:
 
     def qualified_symbol_name(self, symbol):
         if BASE_FILE in symbol:
-            return os.path.join(symbol[PATH], symbol[NAME])
+            html_path = pathlib.Path.joinpath(symbol[PATH], symbol[NAME])
+            return str(html_path)
         return symbol[NAME]
 
     def symbol(self, name, qualified=True):
         self.build_symbol_name_index()
-
         index = self.symbols_by_qualified_name if qualified else self.symbols_by_name
         return index.get(name, None)
 
@@ -98,8 +99,8 @@ class Collector:
         if size:
             sym[SIZE] = int(size)
         if file:
-            sym[PATH] = file
-            sym[BASE_FILE] = os.path.basename(file)
+            sym[PATH] = pathlib.Path(file)
+            sym[BASE_FILE] = sym[PATH].name
         if line:
             sym[LINE] = line
         if assembly_lines:
@@ -118,7 +119,11 @@ class Collector:
         return sym
 
     # 00000550 00000034 T main	/Users/behrens/Documents/projects/pebble/puncover/puncover/build/../src/puncover.c:25
-    parse_size_line_re = re.compile(r"^([\da-f]{8})\s+([\da-f]{8})\s+(.)\s+(\w+)(\s+([^:]+):(\d+))?")
+    if os.name == 'nt':
+        parse_size_line_re = re.compile(r"^([\da-f]{8})\s+([\da-f]{8})\s+(.)\s+(\w+)(\s+([a-zA-Z]:.+)):(\d+)?")
+    else:
+        parse_size_line_re = re.compile(r"^([\da-f]{8})\s+([\da-f]{8})\s+(.)\s+(\w+)(\s+([^:]+):(\d+))?")
+
 
     def parse_size_line(self, line):
         # print(line)
@@ -196,7 +201,8 @@ class Collector:
         if not match:
             return False
 
-        base_file_name = os.path.basename(match.group(1)) # Seems this can sometimes be the complete file name instead of base_file_name
+        file = match.group(1)
+        base_file_name = os.path.basename(file)
         line = int(match.group(3))
         symbol_name = match.group(5)
         stack_size = int(match.group(6))
@@ -278,17 +284,28 @@ class Collector:
         # warning("Couldn't find symbol for %s:%d:%s" % (base_file_name, line, symbol_name))
         return False
 
-
+    windows_path_pattern = re.compile(r"^([a-zA-Z]+)(:)(\\)(.+)$")
+    
     def normalize_files_paths(self, base_dir):
-        base_dir = os.path.abspath(base_dir) if base_dir else "/"
-
+        base_dir = os.path.abspath(base_dir) if base_dir else pathlib.Path(".")
         for s in self.all_symbols():
             path = s.get(PATH, None)
             if path:
-                if path.startswith(base_dir):
-                    path = os.path.relpath(path, base_dir)
-                elif path.startswith("/"):
-                    path = path[1:]
+                str_path = str(path)
+                abs_win_path = self.windows_path_pattern.match(str_path)
+                if base_dir in path.parents:
+                    path = path.relative_to(base_dir)
+                # Remove root from path
+                elif str_path.startswith("/"):
+                    str_path = str_path[1:]
+                    path = pathlib.Path(str_path)
+                elif abs_win_path:
+                    # prefix drive letter 
+                    # in the rare case where there are two
+                    # files with same path and different drive letter
+                    drive_letter = abs_win_path.group(1)
+                    str_path = abs_win_path.group(1)+"_"+abs_win_path.group(4)
+                    path = pathlib.Path(str_path)
                 s[PATH] = path
 
     def unmangle_cpp_names(self):
@@ -452,12 +469,21 @@ class Collector:
 
     def derive_folders(self):
         for s in self.all_symbols():
-            p = s.get(PATH, "<unknown>/<unknown>")
-            p = os.path.normpath(p)
+            p = s.get(PATH, pathlib.Path("<unknown>/<unknown>"))
+            resolved_path = p.resolve(strict=False)
+            if not p.is_absolute():
+                # pathlib prepends cwd if it couldnt 
+            	# resolve locally the file
+                cwd = pathlib.Path().absolute()
+                # remove cwd as it is not part of the relative path
+                p = resolved_path.relative_to(cwd)
+            else:
+                p = resolved_path
             s[PATH] = p
-            s[BASE_FILE] = os.path.basename(p)
+            s[BASE_FILE] = pathlib.Path(p.name)
             s[FILE] = self.file_for_path(p)
             s[FILE][SYMBOLS].append(s)
+
 
     def file_element_for_path(self, path, type, default_values):
         if not path:
@@ -465,8 +491,13 @@ class Collector:
 
         result = self.file_elements.get(path, None)
         if not result:
-            parent_dir = os.path.dirname(path)
-            parent_folder = self.folder_for_path(parent_dir) if parent_dir and parent_dir != "/" else None
+            parent_len = len(path.parents)
+            if parent_len > 0:
+                parent_dir = path.parents[0]
+            else:
+                parent_dir = path
+            parent_available = parent_len > 0 and parent_dir != pathlib.Path(".")
+            parent_folder = self.folder_for_path(parent_dir) if parent_available else None 
             result = {
                 TYPE: type,
                 PATH: path,

--- a/puncover/collector.py
+++ b/puncover/collector.py
@@ -482,7 +482,7 @@ class Collector:
                     resolved_path = p.resolve(strict=False)
                 else:
                     resolved_path = p
-                if windows_os and PYTHON_VER["major"]==3 and PYTHON_VER["minor"]<9:
+                if windows_os and PYTHON_VER["major"]==3 and PYTHON_VER["minor"]<10:
                     pathlib_prepends_cwd = False
                 else:
                     pathlib_prepends_cwd = True

--- a/puncover/collector.py
+++ b/puncover/collector.py
@@ -482,10 +482,14 @@ class Collector:
                     resolved_path = p.resolve(strict=False)
                 else:
                     resolved_path = p
-                cwd_prepend_to_path = PYTHON_VER["major"]==3 and PYTHON_VER["minor"]>9 and windows_os
+                if windows_os and PYTHON_VER["major"]==3 and PYTHON_VER["minor"]<9:
+                    pathlib_prepends_cwd = False
+                else:
+                    pathlib_prepends_cwd = True
+                    
                 if (not p.is_absolute() 
                     and not win_parsing_posix
-                    and cwd_prepend_to_path): 
+                    and pathlib_prepends_cwd): 
                     # pathlib prepends cwd if it couldnt 
                     # resolve locally the file
                     cwd = pathlib.Path().absolute()

--- a/puncover/collector.py
+++ b/puncover/collector.py
@@ -38,6 +38,8 @@ CALLERS = "callers"
 DEEPEST_CALLEE_TREE = "deepest_callee_tree"
 DEEPEST_CALLER_TREE = "deepest_caller_tree"
 
+PYTHON_VER = {"major": sys.version_info[0], "minor": sys.version_info[1]}
+
 def warning(*objs):
     print("WARNING: ", *objs, file=sys.stderr)
 
@@ -479,11 +481,13 @@ class Collector:
                     resolved_path = p.resolve(strict=False)
                 else:
                     resolved_path = p
-                if not p.is_absolute() and not win_parsing_posix:
+                cwd_prepend_to_path = PYTHON_VER["major"]==3 and PYTHON_VER["minor"]>9
+                if (not p.is_absolute() 
+                    and not win_parsing_posix
+                    and cwd_prepend_to_path): 
                     # pathlib prepends cwd if it couldnt 
                     # resolve locally the file
                     cwd = pathlib.Path().absolute()
-                    # remove cwd as it is not part of the relative path
                     p = resolved_path.relative_to(cwd)
                 else:
                     p = resolved_path

--- a/puncover/collector.py
+++ b/puncover/collector.py
@@ -202,7 +202,7 @@ class Collector:
             return False
 
         file = pathlib.Path(match.group(1))
-        base_file_name = file.name
+        base_file_name = pathlib.Path(file.name)
         line = int(match.group(3))
         symbol_name = match.group(5)
         stack_size = int(match.group(6))

--- a/puncover/collector.py
+++ b/puncover/collector.py
@@ -469,27 +469,28 @@ class Collector:
 
     def derive_folders(self):
         for s in self.all_symbols():
-            p = s.get(PATH, pathlib.Path("<unknown>/<unknown>"))
-            posix_root_path = str(p).startswith("\\")
-            # Detects if parsing posix paths in elf in a windows machine
-            win_parsing_posix = (os.name == "nt" and posix_root_path) 
-            if not win_parsing_posix:
-                resolved_path = p.resolve(strict=False)
-            else:
-                resolved_path = p
-            if not p.is_absolute() and not win_parsing_posix:
-                # pathlib prepends cwd if it couldnt 
-            	# resolve locally the file
-                cwd = pathlib.Path().absolute()
-                # remove cwd as it is not part of the relative path
-                p = resolved_path.relative_to(cwd)
-            else:
-                p = resolved_path
+            unknown_path = pathlib.Path("<unknown>/<unknown>")
+            p = s.get(PATH, unknown_path)
+            if p != unknown_path:
+                posix_root_path = str(p).startswith("\\")
+                # Detects if parsing posix paths in elf in a windows machine
+                win_parsing_posix = (os.name == "nt" and posix_root_path) 
+                if not win_parsing_posix:
+                    resolved_path = p.resolve(strict=False)
+                else:
+                    resolved_path = p
+                if not p.is_absolute() and not win_parsing_posix:
+                    # pathlib prepends cwd if it couldnt 
+                    # resolve locally the file
+                    cwd = pathlib.Path().absolute()
+                    # remove cwd as it is not part of the relative path
+                    p = resolved_path.relative_to(cwd)
+                else:
+                    p = resolved_path
             s[PATH] = p
             s[BASE_FILE] = p.name
             s[FILE] = self.file_for_path(p)
             s[FILE][SYMBOLS].append(s)
-
 
     def file_element_for_path(self, path, type, default_values):
         if not path:

--- a/puncover/collector.py
+++ b/puncover/collector.py
@@ -202,7 +202,7 @@ class Collector:
             return False
 
         file = pathlib.Path(match.group(1))
-        base_file_name = pathlib.Path(file.name)
+        base_file_name = file.name
         line = int(match.group(3))
         symbol_name = match.group(5)
         stack_size = int(match.group(6))
@@ -486,7 +486,7 @@ class Collector:
             else:
                 p = resolved_path
             s[PATH] = p
-            s[BASE_FILE] = pathlib.Path(p.name)
+            s[BASE_FILE] = p.name
             s[FILE] = self.file_for_path(p)
             s[FILE][SYMBOLS].append(s)
 

--- a/puncover/collector.py
+++ b/puncover/collector.py
@@ -470,8 +470,14 @@ class Collector:
     def derive_folders(self):
         for s in self.all_symbols():
             p = s.get(PATH, pathlib.Path("<unknown>/<unknown>"))
-            resolved_path = p.resolve(strict=False)
-            if not p.is_absolute():
+            posix_root_path = str(p).startswith("\\")
+            # Detects if parsing posix paths in elf in a windows machine
+            win_parsing_posix = (os.name == "nt" and posix_root_path) 
+            if not win_parsing_posix:
+                resolved_path = p.resolve(strict=False)
+            else:
+                resolved_path = p
+            if not p.is_absolute() and not win_parsing_posix:
                 # pathlib prepends cwd if it couldnt 
             	# resolve locally the file
                 cwd = pathlib.Path().absolute()

--- a/puncover/gcc_tools.py
+++ b/puncover/gcc_tools.py
@@ -14,6 +14,8 @@ class GCCTools:
 
     def gcc_tool_path(self, name):
         path = self.gcc_base_filename + name
+        if os.name == 'nt':
+            path+=".exe"
         if not os.path.isfile(path):
             raise Exception("Could not find %s" % path)
 

--- a/puncover/gcc_tools.py
+++ b/puncover/gcc_tools.py
@@ -26,11 +26,11 @@ class GCCTools:
         return [l.decode() for l in proc.stdout.readlines()]
 
     def get_assembly_lines(self, elf_file):
-        return self.gcc_tool_lines('objdump', ['-dslw', os.path.basename(elf_file)], os.path.dirname(elf_file))
+        return self.gcc_tool_lines('objdump', ['-dslw',  elf_file.name], elf_file.parents[0])
 
     def get_size_lines(self, elf_file):
         # http://linux.die.net/man/1/nm
-        return self.gcc_tool_lines('nm', ['-Sl', os.path.basename(elf_file)], os.path.dirname(elf_file))
+        return self.gcc_tool_lines('nm', ['-Sl', elf_file.name], elf_file.parents[0])
 
     # See https://blog.flameeyes.eu/2010/06/c-name-demangling/ for context
     #

--- a/puncover/renderers.py
+++ b/puncover/renderers.py
@@ -7,6 +7,7 @@ except ImportError:
 
 import itertools
 import re
+import pathlib
 
 import jinja2
 import markupsafe
@@ -296,12 +297,14 @@ class PathRenderer(HTMLRenderer):
         if path.endswith("/"):
             path = path[:-1]
 
+        generic_path = pathlib.Path(path)
         symbol = self.collector.symbol(path)
+
         if symbol:
             self.template_vars["symbol"] = symbol
             return self.render_template("symbol.html.jinja", "symbol")
 
-        file_element = self.collector.file_elements.get(path, None)
+        file_element = self.collector.file_elements.get(generic_path, None)
         if file_element and file_element[collector.TYPE] == collector.TYPE_FILE:
             self.template_vars["file"] = file_element
             return self.render_template("file.html.jinja", path)

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
     url="https://github.com/hbehrens/puncover",
     download_url="https://github.com/hbehrens/puncover/tarball/%s" % __version__,
     author="Heiko Behrens",
+    maintainer="Victor Chavez",
     license="MIT",
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -203,7 +203,7 @@ $t():
         line = "puncover.c:14:40:0	16	dynamic,bounded"
         c = Collector(None)
         c.symbols = {"123": {
-            "base_file": "puncover.c",
+            "base_file": pathlib.Path("puncover.c"),
             "line": 14,
         }}
         self.assertTrue(c.parse_stack_usage_line(line))
@@ -214,7 +214,7 @@ $t():
         line = "puncover.c:8:43:dynamic_stack2	16	dynamic"
         c = Collector(None)
         c.symbols = {"123": {
-            "base_file": "puncover.c",
+            "base_file": pathlib.Path("puncover.c"),
             "line": 8,
         }}
         self.assertTrue(c.parse_stack_usage_line(line))
@@ -223,7 +223,7 @@ $t():
         line = "ILI9341_t3.h:312:15:void ILI9341_t3::updateDisplayClip()	16	static"
         c = Collector(None)
         c.symbols = {"123": {
-            "base_file": "ILI9341_t3.h",
+            "base_file": pathlib.Path("ILI9341_t3.h"),
             "line": 312,
         }}
         self.assertTrue(c.parse_stack_usage_line(line))
@@ -232,7 +232,7 @@ $t():
         line = "Print.cpp:34:8:virtual size_t Print::write(const uint8_t*, size_t)	24	static"
         c = Collector(None)
         c.symbols = {"123": {
-            "base_file": "Print.cpp",
+            "base_file": pathlib.Path("Print.cpp"),
             "line": 34,
         }}
         self.assertTrue(c.parse_stack_usage_line(line))
@@ -243,7 +243,7 @@ $t():
         line = "Print.cpp:34:8:virtual size_t Print::write(const uint8_t*, size_t)	24	static"
         c = Collector(None)
         c.symbols = {"123": {
-            "base_file": "Print.cpp",
+            "base_file": pathlib.Path("Print.cpp"),
             "display_name": "virtual size_t Print::write(const uint8_t*, size_t)",
             "line": 35,
         }}
@@ -255,7 +255,7 @@ $t():
         line = "WString.cpp:82:1:String::String(unsigned int, unsigned char)	32	static"
         c = Collector(None)
         c.symbols = {"123": {
-            "base_file": "WString.cpp",
+            "base_file": pathlib.Path("WString.cpp"),
             "line": 82,
         }}
         self.assertTrue(c.parse_stack_usage_line(line))

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -203,7 +203,7 @@ $t():
         line = "puncover.c:14:40:0	16	dynamic,bounded"
         c = Collector(None)
         c.symbols = {"123": {
-            "base_file": pathlib.Path("puncover.c"),
+            "base_file": "puncover.c",
             "line": 14,
         }}
         self.assertTrue(c.parse_stack_usage_line(line))
@@ -214,7 +214,7 @@ $t():
         line = "puncover.c:8:43:dynamic_stack2	16	dynamic"
         c = Collector(None)
         c.symbols = {"123": {
-            "base_file": pathlib.Path("puncover.c"),
+            "base_file": "puncover.c",
             "line": 8,
         }}
         self.assertTrue(c.parse_stack_usage_line(line))
@@ -223,7 +223,7 @@ $t():
         line = "ILI9341_t3.h:312:15:void ILI9341_t3::updateDisplayClip()	16	static"
         c = Collector(None)
         c.symbols = {"123": {
-            "base_file": pathlib.Path("ILI9341_t3.h"),
+            "base_file": "ILI9341_t3.h",
             "line": 312,
         }}
         self.assertTrue(c.parse_stack_usage_line(line))
@@ -232,7 +232,7 @@ $t():
         line = "Print.cpp:34:8:virtual size_t Print::write(const uint8_t*, size_t)	24	static"
         c = Collector(None)
         c.symbols = {"123": {
-            "base_file": pathlib.Path("Print.cpp"),
+            "base_file": "Print.cpp",
             "line": 34,
         }}
         self.assertTrue(c.parse_stack_usage_line(line))
@@ -243,7 +243,7 @@ $t():
         line = "Print.cpp:34:8:virtual size_t Print::write(const uint8_t*, size_t)	24	static"
         c = Collector(None)
         c.symbols = {"123": {
-            "base_file": pathlib.Path("Print.cpp"),
+            "base_file": "Print.cpp",
             "display_name": "virtual size_t Print::write(const uint8_t*, size_t)",
             "line": 35,
         }}
@@ -255,7 +255,7 @@ $t():
         line = "WString.cpp:82:1:String::String(unsigned int, unsigned char)	32	static"
         c = Collector(None)
         c.symbols = {"123": {
-            "base_file": pathlib.Path("WString.cpp"),
+            "base_file": "WString.cpp",
             "line": 82,
         }}
         self.assertTrue(c.parse_stack_usage_line(line))
@@ -399,7 +399,7 @@ uses_doubles2():
         self.assertNotIn(collector.BASE_FILE, s)
         c.derive_folders()
         self.assertEqual(pathlib.Path("<unknown>/<unknown>"), s[collector.PATH])
-        self.assertEqual(pathlib.Path("<unknown>"), s[collector.BASE_FILE])
+        self.assertEqual("<unknown>", s[collector.BASE_FILE])
         self.assertIn(collector.FILE, s)
         file = s[collector.FILE]
         self.assertEqual("<unknown>", file[collector.NAME])


### PR DESCRIPTION
Based on the comments from @noahp  I have rebased my [last](https://github.com/HBehrens/puncover/pull/64) pull request to veriify that unit tests pass for different versions with github actions and python module tox.

## Changes

### Fixed

- Unit tests due to parsing of basefile name as  a pathlib type. Changed to string representation.
- Path for elf file was not working in windows. Parsing elf_file_path as pathlib to have a generic path representation to fix this.



