### PR TITLE
Feature/support windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,7 @@ jobs:
         os: [
             ubuntu-20.04,
             macos-12,
-            # windows is disabled until path support works there
-            # windows-2022,
+            windows-latest,
           ]
       fail-fast: false
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /dist/
 .tox
 .coverage
+venv

--- a/puncover/collector.py
+++ b/puncover/collector.py
@@ -466,7 +466,7 @@ class Collector:
         result = self.file_elements.get(path, None)
         if not result:
             parent_dir = os.path.dirname(path)
-            parent_folder = self.folder_for_path(parent_dir) if parent_dir and parent_dir != "/" else None
+            parent_folder = self.folder_for_path(parent_dir) if parent_dir and parent_dir != os.path.sep else None
             result = {
                 TYPE: type,
                 PATH: path,

--- a/puncover/gcc_tools.py
+++ b/puncover/gcc_tools.py
@@ -1,10 +1,13 @@
 import os
 import subprocess
+import sys
 
 import itertools
 
 
 class GCCTools:
+    _TOOLS_POSTFIX = ".exe" if sys.platform == "win32" else ""
+
     def __init__(self, gcc_base_filename):
         # if base filename is a directory, make sure we have the trailing slash
         if os.path.isdir(gcc_base_filename):
@@ -13,7 +16,7 @@ class GCCTools:
         self.gcc_base_filename = gcc_base_filename
 
     def gcc_tool_path(self, name):
-        path = self.gcc_base_filename + name
+        path = self.gcc_base_filename + name + self._TOOLS_POSTFIX
         if not os.path.isfile(path):
             raise Exception("Could not find %s" % path)
 

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -359,13 +359,13 @@ uses_doubles2():
         }
 
         c.derive_folders()
-        self.assertEqual("/Users/behrens/Documents/projects/pebble/puncover/pebble/src/puncover.c", s1[collector.PATH])
+        self.assertEqual(os.path.normpath("/Users/behrens/Documents/projects/pebble/puncover/pebble/src/puncover.c"), s1[collector.PATH])
         self.assertIsNotNone(s1[collector.FILE])
 
-        self.assertEqual("/Users/thomas/work/arm-eabi-toolchain/gcc-4.7-2012.09/libgcc/config/arm/ieee754-df.S", s2[collector.PATH])
+        self.assertEqual(os.path.normpath("/Users/thomas/work/arm-eabi-toolchain/gcc-4.7-2012.09/libgcc/config/arm/ieee754-df.S"), s2[collector.PATH])
         self.assertIsNotNone(s2[collector.FILE])
 
-        self.assertEqual("src/puncover.c", s3[collector.PATH])
+        self.assertEqual(os.path.normpath("src/puncover.c"), s3[collector.PATH])
         self.assertIsNotNone(s3[collector.FILE])
 
     def test_derive_file_elements_for_unknown_files(self):

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 from puncover.collector import Collector, left_strip_from_list
 from mock import patch
@@ -374,7 +375,7 @@ uses_doubles2():
         self.assertNotIn(collector.PATH, s)
         self.assertNotIn(collector.BASE_FILE, s)
         c.derive_folders()
-        self.assertEqual("<unknown>/<unknown>", s[collector.PATH])
+        self.assertEqual(os.path.join("<unknown>", "<unknown>"), s[collector.PATH])
         self.assertEqual("<unknown>", s[collector.BASE_FILE])
         self.assertIn(collector.FILE, s)
         file = s[collector.FILE]
@@ -386,17 +387,17 @@ uses_doubles2():
 
     def test_enhance_file_elements(self):
         c = Collector(None)
-        aa_c = c.file_for_path("a/a/aa.c")
-        ab_c = c.file_for_path("a/b/ab.c")
-        b_c = c.file_for_path("b/b.c")
-        baa_c = c.file_for_path("b/a/a/baa.c")
+        aa_c = c.file_for_path(os.path.join("a", "a", "aa.c"))
+        ab_c = c.file_for_path(os.path.join("a", "b", "ab.c"))
+        b_c = c.file_for_path(os.path.join("b", "b.c"))
+        baa_c = c.file_for_path(os.path.join("b", "a", "a", "baa.c"))
 
         a = c.folder_for_path("a")
-        aa = c.folder_for_path("a/a")
-        ab = c.folder_for_path("a/b")
+        aa = c.folder_for_path(os.path.join("a", "a"))
+        ab = c.folder_for_path(os.path.join("a", "b"))
         b = c.folder_for_path("b")
-        ba = c.folder_for_path("b/a")
-        baa = c.folder_for_path("b/a/a")
+        ba = c.folder_for_path(os.path.join("b", "a"))
+        baa = c.folder_for_path(os.path.join("b", "a", "a"))
 
         self.assertEqual("a", a[collector.NAME])
         self.assertEqual("a", aa[collector.NAME])
@@ -434,11 +435,11 @@ uses_doubles2():
         self.assertListEqual([baa_c], baa[collector.FILES])
 
         self.assertEqual("a", a[collector.COLLAPSED_NAME])
-        self.assertEqual("a/a", aa[collector.COLLAPSED_NAME])
-        self.assertEqual("a/b", ab[collector.COLLAPSED_NAME])
+        self.assertEqual(os.path.join("a", "a"), aa[collector.COLLAPSED_NAME])
+        self.assertEqual(os.path.join("a", "b"), ab[collector.COLLAPSED_NAME])
         self.assertEqual("b", b[collector.COLLAPSED_NAME])
         self.assertEqual("a", ba[collector.COLLAPSED_NAME])
-        self.assertEqual("a/a", baa[collector.COLLAPSED_NAME])
+        self.assertEqual(os.path.join("a", "a"), baa[collector.COLLAPSED_NAME])
 
         self.assertListEqual([aa, ab], a[collector.COLLAPSED_SUB_FOLDERS])
         self.assertListEqual([], aa[collector.COLLAPSED_SUB_FOLDERS])


### PR DESCRIPTION
This tool looks great!  Windows seems to work with a minimal change (adding .exe to the GCC tools and using platform agnostic path separator) but it made sense to have the unit tests pass for Windows and reenable the CI.

I'm not sure that the tool is fully Windows-compatible as-is.  For example, under object names I only see entries in the code column.  Stack column seems to be working for functions.

I'll run it on a Linux VM when I have a chance to see what it's supposed to look like - but I think a non-invasive change with regression testing is a good first step.