### PR TITLE
Initial fix for https://github.com/HBehrens/puncover/issues/79

### DIFF
--- a/puncover/puncover.py
+++ b/puncover/puncover.py
@@ -52,7 +52,10 @@ def open_browser(host, port):
 
 
 def main():
-    gcc_tools_base = os.path.join(find_arm_tools_location(), 'bin/arm-none-eabi-')
+    try:
+        gcc_tools_base = os.path.join(find_arm_tools_location(), 'bin/arm-none-eabi-')
+    except TypeError:
+        gcc_tools_base = None
 
     parser = argparse.ArgumentParser(
         description="Analyses C/C++ build output for code size, static variables, and stack usage.",


### PR DESCRIPTION
Wrap initial default gcc_tools_base detection in try/except. This is just to get the "argparse" part of the code going so users get a chance to specify the "gcc_tools_base" through the "--gcc-tools-base" cmd line argument, but it does not ensure that the given base is valid which will cause a similar exception later if:
- no "--gcc-tools-base" is given and auto-detection fails
- the given "--gcc-tools-base" is invalid

But at least, it allows users to execute puncover at all (if only to get the help ;))