### PR TITLE
Bump codecov version

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
-codecov==2.1.12
+codecov==2.1.13
 mock==4.0.3
 pytest==7.0.1
 pytest-cov==3.0.0


### PR DESCRIPTION
I think they pulled 2.1.12:

https://pypi.org/project/codecov/#history

It's also deprecated, we should switch to the new uploader:

https://docs.codecov.com/docs/codecov-uploader#using-the-uploader
