### PR TITLE
Fix file path normalization

### DIFF
--- a/puncover/collector.py
+++ b/puncover/collector.py
@@ -292,7 +292,7 @@ class Collector:
     windows_path_pattern = re.compile(r"^([a-zA-Z]+)(:)(\\)(.+)$")
 
     def normalize_files_paths(self, base_dir):
-        base_dir = os.path.abspath(base_dir) if base_dir else pathlib.Path(".")
+        base_dir = pathlib.Path(base_dir).absolute() if base_dir else pathlib.Path(".")
         for s in self.all_symbols():
             path = s.get(PATH, None)
             if path:


### PR DESCRIPTION
This PR fixes a bug where `base_dir` is ignored and all paths in the generated report are absolute.

In `normalize_files_paths` function `base_dir` is normalized as  `os.path.abspath(base_dir)`, but this function returns a string. Then `base_dir in path.parents` condition fails to detect that we are inside base directory, because it expects `pathlib.Path` not string.

This PR fixes problem by making `base_dir` always an instance of `pathlib.Path`.
