### PR TITLE
move enhance_call_tree_pattern to gcc_tools, and teach gcc_tools how to pick up call trees for RISC-V

### DIFF
--- a/puncover/collector.py
+++ b/puncover/collector.py
@@ -386,18 +386,11 @@ class Collector:
                 if callee_file and caller_file and callee_file != caller_file:
                     callee["called_from_other_file"] = True
 
-    #  934:	f7ff bba8 	b.w	88 <jump_to_pbl_function>
-    # 8e4:	f000 f824 	bl	930 <app_log>
-    #
-    # but not:
-    # 805bbac:	2471 0805 b64b 0804 b3c9 0804 b459 0804     q$..K.......Y...
-    enhance_call_tree_pattern = re.compile(r"^\s*[\da-f]+:\s+[\d\sa-f]{9}\s+BL?(EQ|NE|CS|HS|CC|LO|MI|PL|VS|VC|HI|LS|GE|LT|GT|LE|AL)?(\.W|\.N)?\s+([\d\sa-f]+)", re.IGNORECASE)
-
     def enhance_call_tree_from_assembly_line(self, function, line):
         if "<" not in line:
             return False
 
-        match = self.enhance_call_tree_pattern.match(line)
+        match = self.gcc_tools.enhance_call_tree_pattern.match(line)
 
         if match:
             callee = self.symbol_by_addr(match.group(3))

--- a/puncover/gcc_tools.py
+++ b/puncover/gcc_tools.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import re
 
 import itertools
 
@@ -11,6 +12,16 @@ class GCCTools:
             gcc_base_filename = os.path.join(gcc_base_filename, '')
 
         self.gcc_base_filename = gcc_base_filename
+
+        if 'riscv' in gcc_base_filename:
+            self.enhance_call_tree_pattern = re.compile(r"^\s*[\da-f]+:\s+[\d\sa-f]{9}\s+(J|JAL|JR|JALR|BEQZ|BNEZ|BEQ|BNE|NLT|BGE|BLTU|BGEU)()\s+([\d\sa-f]+)", re.IGNORECASE)
+        else: # ARM
+            #  934:	f7ff bba8 	b.w	88 <jump_to_pbl_function>
+            # 8e4:	f000 f824 	bl	930 <app_log>
+            #
+            # but not:
+            # 805bbac:	2471 0805 b64b 0804 b3c9 0804 b459 0804     q$..K.......Y...
+            self.enhance_call_tree_pattern = re.compile(r"^\s*[\da-f]+:\s+[\d\sa-f]{9}\s+BL?(EQ|NE|CS|HS|CC|LO|MI|PL|VS|VC|HI|LS|GE|LT|GT|LE|AL)?(\.W|\.N)?\s+([\d\sa-f]+)", re.IGNORECASE)
 
     def gcc_tool_path(self, name):
         path = self.gcc_base_filename + name


### PR DESCRIPTION
I think `enhance_call_tree_pattern` is the only bit of arch-specific code.  Probably in an ideal universe it would go into some `arch/` library, but for now, `gcc_tools` is the one that knows what arch we're targeting (sort of), so I move that pattern there.  Then, I add support for branch patterns for RISC-V.  This allows puncover to track stack usage on RV32 / LiteX.