### PR TITLE
fix: remove deprecated distutils module

### DIFF
--- a/puncover/puncover.py
+++ b/puncover/puncover.py
@@ -3,7 +3,7 @@
 import argparse
 import os
 import webbrowser
-from distutils.spawn import find_executable
+import shutil
 from os.path import dirname
 from threading import Timer
 
@@ -52,7 +52,7 @@ def get_arm_tools_prefix_path():
     Note that we could instead use the '-print-prog-name=...' option to gcc,
     which returns the paths we need. For now stick with the hacky method here.
     """
-    obj_dump = find_executable("arm-none-eabi-objdump")
+    obj_dump = shutil.which("arm-none-eabi-objdump")
     if not obj_dump:
         return None
 


### PR DESCRIPTION
Python 3.12 removed the distutils module, this made puncover incompatible with the new Python version.

The [PEP](https://peps.python.org/pep-0632/) suggests what to use as [replacement](https://peps.python.org/pep-0632/#migration-advice) of distutils.spawn:
```
For these modules or functions, use the standard library module shown:
    distutils.spawn.find_executable — use the shutil.which function
```