### PR TITLE
Add support for list of worstcase stacks

### DIFF
--- a/puncover/renderers.py
+++ b/puncover/renderers.py
@@ -232,6 +232,7 @@ def sorted_filter(context, symbols):
         'name': lambda e: e.get(collector.DISPLAY_NAME, e.get(collector.NAME, None)).lower(),
         'code': lambda e: to_num(symbol_code_size_filter(context, e)),
         'stack': lambda e: to_num(symbol_stack_size_filter(context, e)),
+        'worst_stack': lambda e: to_num(symbol_worst_stack_size_filter(context, e)),
         'vars': lambda e: to_num(symbol_var_size_filter(context, e)),
     }[sort_id]
 
@@ -341,6 +342,11 @@ class AllSymbolsRenderer(HTMLRenderer):
     def dispatch_request(self, symbol_name=None):
         return self.render_template("all_symbols.html.jinja", "all")
 
+class WorstCasesStacksRenderer(HTMLRenderer):
+
+    def dispatch_request(self, symbol_name=None):
+        return self.render_template("worst_cases_stacks.html.jinja", "worst_cases_stacks")
+
 
 class RackRenderer(HTMLRenderer):
 
@@ -376,6 +382,7 @@ def register_jinja_filters(jinja_env):
 def register_urls(app, collector):
     app.add_url_rule("/", view_func=OverviewRenderer.as_view("overview", collector=collector))
     app.add_url_rule("/all/", view_func=AllSymbolsRenderer.as_view("all", collector=collector))
+    app.add_url_rule("/worst_cases_stacks/", view_func=WorstCasesStacksRenderer.as_view("worst_cases_stacks", collector=collector))
     app.add_url_rule("/path/<path:path>/", view_func=PathRenderer.as_view("path", collector=collector))
     app.add_url_rule("/symbol/<string:symbol_name>", view_func=SymbolRenderer.as_view("symbol", collector=collector))
     app.add_url_rule("/rack/", view_func=RackRenderer.as_view("rack", collector=collector), methods=["GET", "POST"])

--- a/puncover/templates/lists.html.jinja
+++ b/puncover/templates/lists.html.jinja
@@ -107,6 +107,30 @@
     {% if symbol.calls_float_function %}<span class="label label-warning">calls float</span>{% endif %}
 {% endmacro %}
 
+{% macro worst_stacks(functions) -%}
+    <table class="table table-bordered table-hover table-condensed">
+        <thead>
+            <tr>
+                <th width="100%">{{ 'Name' | col_sortable(true) }}</th>
+                <th class="col_size">{{ 'Stack' | col_sortable(true) }}</th>
+            </tr>
+        </thead>
+
+        <tbody>
+            {% for symbol in (functions | sorted) %}
+                {% if symbol.deepest_caller_tree[1] | length <= 1 %}
+                    {% if symbol.deepest_callee_tree[1] | length > 1 %}
+                        <tr>
+                            <td><a href="{{ symbol | symbol_url }}" class="icon-function">{{ symbol.display_name |e }}</a></td>
+                            <td class="col_size">{{ symbol.deepest_callee_tree[1] | symbol_stack_size | bytes }}</td>
+                        </tr>
+                    {% endif %}
+               {% endif %}
+            {% endfor %}
+        </tbody>
+    </table>
+{% endmacro %}
+
 {% macro symbols(functions, variables) -%}
     <table class="table table-bordered table-hover table-condensed">
         <thead>

--- a/puncover/templates/overview.html.jinja
+++ b/puncover/templates/overview.html.jinja
@@ -6,6 +6,7 @@
     {{ lists.directory(root_folders, []) }}
 
     <a class="btn btn-default" href="{{ url_for('all') }}">Show all symbols</a>
+    <a class="btn btn-default" href="{{ url_for('worst_cases_stacks') }}">Show Worst-Cases Stacks</a>
     <a class="btn btn-default" href="{{ url_for('rack') }}">Analyze text snippet</a>
 
 

--- a/puncover/templates/worst_cases_stacks.html.jinja
+++ b/puncover/templates/worst_cases_stacks.html.jinja
@@ -1,0 +1,9 @@
+{% extends "base.html.jinja" %}
+{% block title %}Worst-Cases stacks{% endblock %}
+{% block page_header %}<h1>Worst-Cases Stacks</h1>{% endblock %}
+{% block content %}
+
+    {% import 'lists.html.jinja' as lists with context %}
+    {{ lists.worst_stacks(all_functions) }}
+
+{% endblock %}


### PR DESCRIPTION
This patch should fix https://github.com/HBehrens/puncover/issues/87. It provides a list of all the possible largest stacks.

Notes:
  - It is not possible to sort the list. I would be glad to have some help on this topic
  - The indirect calls (call to pointer to functions) are not supported (see https://github.com/HBehrens/puncover/issues/105). Fully automated support for this case is very difficult. However, we could annotate the paths with indirect calls.
  - An extension of the previous bullet would be list all the places where indirect calls happen. For that, we need a list of all the recursive callees.
