### PR TITLE
Remove python 3.7 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         # setup-python's version support is limited by runner version:
         # https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
         os: [

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 import os
 from pathlib import Path
 
-from setuptools import setup, find_packages, Command
+from setuptools import Command, find_packages, setup
 
 ROOTDIR = Path(__file__).parent
 
@@ -12,7 +12,9 @@ with open(ROOTDIR / "puncover/version.py") as f:
 
 
 with open(ROOTDIR / "requirements-test.txt") as f:
-    tests_require = list(filter(lambda x: not x.strip().startswith('-r'), f.readlines()))
+    tests_require = list(
+        filter(lambda x: not x.strip().startswith("-r"), f.readlines())
+    )
 
 with open(ROOTDIR / "requirements.txt") as f:
     requires = f.readlines()
@@ -52,12 +54,12 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
     ],
     packages=find_packages(exclude=["tests", "tests.*"]),
     include_package_data=True,

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
-# Python3.5 unit tests fail
-envlist = py{36,37,38,39,3.10,3.11,3.12}
+envlist = py{38,39,3.10,3.11,3.12,3.13}
 
 [testenv]
 deps = -rrequirements-test.txt


### PR DESCRIPTION
End of life, and difficult to use on modern github-hosted runners.
