### PR TITLE
Fix crashes when viewing directory with sort=stack

### DIFF
--- a/puncover/renderers.py
+++ b/puncover/renderers.py
@@ -102,13 +102,14 @@ def symbol_var_size_filter(context, value):
 def symbol_stack_size_filter(context, value, stack_base=None):
     if isinstance(stack_base, str):
         stack_base = None
-    result = traverse_filter_wrapper(
+    result = symbol_traverse(
         value,
         lambda s: s.get(collector.STACK_SIZE, None)
         if s.get(collector.TYPE, None) == collector.TYPE_FUNCTION
         else None,
     )
-    return none_sum([result, stack_base])
+    s = none_sum([result, stack_base])
+    return s if s != 0 else ""
 
 
 @jinja2.pass_context

--- a/puncover/renderers.py
+++ b/puncover/renderers.py
@@ -50,25 +50,22 @@ def symbol_file_url_filter(context, value):
     return symbol_url_filter(context, f) if f else None
 
 
-def none_sum(a, b):
-    if a is not None:
-        return a + b if b is not None else a
-    return b
-
+def none_sum(l):
+    values = [a for a in l if a is not None]
+    if values:
+        return sum(values)
+    else:
+        return None
 
 def symbol_traverse(s, func):
     if isinstance(s, list):
-        result = None
-        for si in [symbol_traverse(i, func) for i in s]:
-            if si is not None:
-                result = none_sum(result, si)
-        return result
+        return none_sum([symbol_traverse(i, func) for i in s])
 
     if collector.TYPE in s:
         if s[collector.TYPE] == collector.TYPE_FILE:
-            return sum([symbol_traverse(s, func) for s in s[collector.SYMBOLS]])
+            return none_sum([symbol_traverse(s, func) for s in s[collector.SYMBOLS]])
         if s[collector.TYPE] == collector.FOLDER:
-            return sum([
+            return none_sum([
                 symbol_traverse(s, func)
                 for s in itertools.chain(s[collector.SUB_FOLDERS], s[collector.FILES])
             ])
@@ -111,7 +108,7 @@ def symbol_stack_size_filter(context, value, stack_base=None):
         if s.get(collector.TYPE, None) == collector.TYPE_FUNCTION
         else None,
     )
-    return none_sum(result, stack_base)
+    return none_sum([result, stack_base])
 
 
 @jinja2.pass_context


### PR DESCRIPTION
This fixes crashes where code attempts to sum integers with None or an empty string "" when viewing a source directory with the url argument sort=stack_asc or sort=stack_desc.

How to reproduce:
* View a single .c file,
* click "Stack" column header to sort functions by stack usage,
* click one of the parent directories
* get an "Internal server error" with the following stack trace in the console:

```
[2025-10-06 11:25:51,611] ERROR in app: Exception on /path/[...]/ [GET]
Traceback (most recent call last):
  File "[...]/.venv/lib/python3.13/site-packages/flask/app.py", line 2529, in wsgi_app
    response = self.full_dispatch_request()
  File "[...]/.venv/lib/python3.13/site-packages/flask/app.py", line 1825, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "[...]/.venv/lib/python3.13/site-packages/flask/app.py", line 1823, in full_dispatch_request
    rv = self.dispatch_request()
  File "[...]/.venv/lib/python3.13/site-packages/flask/app.py", line 1799, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "[...]/.venv/lib/python3.13/site-packages/flask/views.py", line 107, in view
    return current_app.ensure_sync(self.dispatch_request)(**kwargs)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "[...]/puncover/puncover/renderers.py", line 349, in dispatch_request
    return self.render_template("folder.html.jinja", path)
           ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "[...]/puncover/puncover/renderers.py", line 294, in render_template
    return render_template(template_name, **self.template_vars)
  File "[...]/.venv/lib/python3.13/site-packages/flask/templating.py", line 147, in render_template
    return _render(app, template, context)
  File "[...]/.venv/lib/python3.13/site-packages/flask/templating.py", line 130, in _render
    rv = template.render(context)
  File "[...]/.venv/lib/python3.13/site-packages/jinja2/environment.py", line 1295, in render
    self.environment.handle_exception()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "[...]/.venv/lib/python3.13/site-packages/jinja2/environment.py", line 942, in handle_exception
    raise rewrite_traceback_stack(source=source)
  File "[...]/puncover/puncover/templates/folder.html.jinja", line 2, in top-level template code
    {% import 'lists.html.jinja' as lists with context %}
    ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "[...]/puncover/puncover/templates/base.html.jinja", line 32, in top-level template code
    {% block content %}{% endblock %}
    ^^^^^^^^^^^^^^^^^
  File "[...]/puncover/puncover/templates/folder.html.jinja", line 6, in block 'content'
    {{ lists.directory(folder.sub_folders, folder.files) }}
    ^^^^^^^^^^^^^^^^^^^^^
  File "[...]/.venv/lib/python3.13/site-packages/jinja2/runtime.py", line 784, in _invoke
    rv = self._func(*arguments)
  File "[...]/puncover/puncover/templates/lists.html.jinja", line 39, in template
    {% for folder in (folders | sorted) %}
    ^^^^^^^^^^^^^
  File "[...]/puncover/puncover/renderers.py", line 273, in sorted_filter
    return list(sorted(symbols, key=key, reverse=(sort_order == "desc")))
                ~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "[...]/puncover/puncover/renderers.py", line 269, in <lambda>
    "stack": lambda e: to_num(symbol_stack_size_filter(context, e)),
                              ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
  File "[...]/puncover/puncover/renderers.py", line 108, in symbol_stack_size_filter
    result = traverse_filter_wrapper(
        value,
    ...<2 lines>...
        else None,
    )
  File "[...]/puncover/puncover/renderers.py", line 80, in traverse_filter_wrapper
    result = symbol_traverse(value, func)
  File "[...]/puncover/puncover/renderers.py", line 72, in symbol_traverse
    symbol_traverse(s, func)
    ~~~~~~~~~~~~~~~^^^^^^^^^
  File "[...]/puncover/puncover/renderers.py", line 72, in symbol_traverse
    symbol_traverse(s, func)
    ~~~~~~~~~~~~~~~^^^^^^^^^
  File "[...]/puncover/puncover/renderers.py", line 69, in symbol_traverse
    return sum([symbol_traverse(s, func) for s in s[collector.SYMBOLS]])
TypeError: unsupported operand type(s) for +: 'int' and 'NoneType'
```