### PR TITLE
Add back `--gcc_tools_base` arg variant

### DIFF
--- a/puncover/puncover.py
+++ b/puncover/puncover.py
@@ -78,6 +78,7 @@ def main():
     )
     parser.add_argument(
         "--gcc-tools-base",
+        "--gcc_tools_base",
         default=gcc_tools_base,
         help="filename prefix for your gcc tools, e.g. ~/arm-cs-tools/bin/arm-none-eabi-",
     )


### PR DESCRIPTION
Taking the idea from #125 and adding back the previously removed argument variant [`--gcc_tools_base`](https://github.com/HBehrens/puncover/pull/121/files#diff-5789312f1eca2ac88f5472eecfd829ca7e250d67b9fe962a3af5dce002326922L79) in [release 0.6.0](https://github.com/HBehrens/puncover/releases/tag/0.6.0).

This PR will fix #127 and allow Zephyr's build target `puncover` to work again.



