### PR TITLE
annotate indirect calls in functions

### DIFF
--- a/puncover/collector.py
+++ b/puncover/collector.py
@@ -73,6 +73,8 @@ class StubGccTool:
         re.IGNORECASE,
     )
 
+    indirect_call_pattern = None
+
 
 class Collector:
     def __init__(self, gcc_tools):
@@ -434,7 +436,7 @@ class Collector:
                 if callee_file and caller_file and callee_file != caller_file:
                     callee["called_from_other_file"] = True
 
-    def enhance_call_tree_from_assembly_line(self, function, line):
+    def add_function_call_from_assembly_line(self, function, line):
         if "<" not in line:
             return False
 
@@ -447,6 +449,21 @@ class Collector:
                 return True
 
         return False
+
+    def annotate_indirect_call(self, function, line):
+        if self.gcc_tools.indirect_call_pattern is None:
+            return False
+
+        match = self.gcc_tools.indirect_call_pattern.match(line)
+        if match:
+            function["performs_indirect_call"] = True
+            return True
+
+        return False
+
+    def enhance_call_tree_from_assembly_line(self, function, line):
+        self.add_function_call_from_assembly_line(function, line)
+        self.annotate_indirect_call(function, line)
 
     def enhance_call_tree(self):
         for f in self.all_functions():

--- a/puncover/gcc_tools.py
+++ b/puncover/gcc_tools.py
@@ -17,6 +17,9 @@ class GCCTools:
                 r"^\s*[\da-f]+:\s+[\d\sa-f]{9}\s+(J|JAL|JR|JALR|BEQZ|BNEZ|BEQ|BNE|NLT|BGE|BLTU|BGEU)()\s+([\d\sa-f]+)",
                 re.IGNORECASE,
             )
+
+            # TODO: i don't know how to detect indirect calls in riscv
+            self.indirect_call_pattern = None
         else:  # ARM
             #  934:	f7ff bba8 	b.w	88 <jump_to_pbl_function>
             # 8e4:	f000 f824 	bl	930 <app_log>
@@ -26,6 +29,11 @@ class GCCTools:
             self.enhance_call_tree_pattern = re.compile(
                 r"^\s*[\da-f]+:\s+[\d\sa-f]{9}\s+BL?(EQ|NE|CS|HS|CC|LO|MI|PL|VS|VC|HI|LS|GE|LT|GT|LE|AL)?(\.W|\.N)?\s+([\d\sa-f]+)",
                 re.IGNORECASE,
+            )
+
+            # 805d83c:	47b0      	blx	r6
+            self.indirect_call_pattern = re.compile(
+                r"^\s*([\da-f]+):\s+[\d\sa-f]{9}\s+BLX\s+(\w+)$", re.IGNORECASE
             )
 
     def gcc_tool_path(self, name):

--- a/puncover/templates/lists.html.jinja
+++ b/puncover/templates/lists.html.jinja
@@ -105,6 +105,7 @@
 {% macro symbol_remarks(symbol) %}
     {% if symbol.called_from_other_file %}<span class="label label-success">x-module</span>{% endif %}
     {% if symbol.calls_float_function %}<span class="label label-warning">calls float</span>{% endif %}
+    {% if symbol.performs_indirect_call %}<span class="label label-danger">indirect call</span>{% endif %}
 {% endmacro %}
 
 {% macro symbols(functions, variables) -%}

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -251,6 +251,38 @@ $t():
             )
             self.assertFalse(m.called)
 
+    def test_annotate_indirect_call(self):
+        import re
+        from unittest.mock import MagicMock
+
+        gcc_tools = MagicMock()
+        gcc_tools.indirect_call_pattern = re.compile(
+            r"^\s*([\da-f]+):\s+[\d\sa-f]{9}\s+BLX\s+(\w+)$", re.IGNORECASE
+        )
+        c = Collector(gcc_tools)
+
+        # indirect call via register — should set flag
+        f = {}
+        self.assertTrue(c.annotate_indirect_call(f, "805d83c:\t47b0     \tblx\tr6"))
+        self.assertTrue(f.get("performs_indirect_call"))
+
+        # direct call with label — should NOT match
+        f2 = {}
+        self.assertFalse(c.annotate_indirect_call(f2, "8e4:\tf000 f824\tblx\t930 <app_log>"))
+        self.assertFalse(f2.get("performs_indirect_call"))
+
+        # unrelated instruction — should NOT match
+        f3 = {}
+        self.assertFalse(c.annotate_indirect_call(f3, " 89e:\te9d3 0100\tldrd\tr0, r1, [r3]"))
+        self.assertFalse(f3.get("performs_indirect_call"))
+
+    def test_annotate_indirect_call_none_pattern(self):
+        # When indirect_call_pattern is None (e.g. RISC-V), should return False and not crash
+        c = Collector(None)
+        f = {}
+        self.assertFalse(c.annotate_indirect_call(f, "805d83c:\t47b0     \tblx\tr6"))
+        self.assertFalse(f.get("performs_indirect_call"))
+
     def test_stack_usage_line(self):
         line = "puncover.c:14:40:0	16	dynamic,bounded"
         c = Collector(None)

--- a/tests/test_gcc_tools.py
+++ b/tests/test_gcc_tools.py
@@ -6,6 +6,22 @@ from puncover.gcc_tools import GCCTools
 
 
 class TestGCCTools(unittest.TestCase):
+    def test_arm_indirect_call_pattern(self):
+        t = GCCTools("arm-none-eabi-")
+        p = t.indirect_call_pattern
+        self.assertIsNotNone(p)
+
+        # matches indirect call via register
+        self.assertIsNotNone(p.match("805d83c:\t47b0     \tblx\tr6"))
+        # case-insensitive
+        self.assertIsNotNone(p.match("805d83c:\t47b0     \tBLX\tr6"))
+        # direct call with label suffix should NOT match
+        self.assertIsNone(p.match("8e4:\tf000 f824\tblx\t930 <app_log>"))
+
+    def test_riscv_indirect_call_pattern_is_none(self):
+        t = GCCTools("riscv32-unknown-elf-")
+        self.assertIsNone(t.indirect_call_pattern)
+
     def test_chunks_and_rstrip(self):
         t = GCCTools("somePath")
         with patch.object(t, "gcc_tool_lines") as f:


### PR DESCRIPTION
partially resolves #113 

detect indirect calls by finding `BLX` instructions in ARM.

<img width="1193" height="484" alt="image" src="https://github.com/user-attachments/assets/6d70e84b-68ca-4dac-8f0e-0f042193ed3a" />
