### PR TITLE
chore: remove python 3.9 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         # setup-python's version support is limited by runner version:
         # https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
         os: [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     { name = "Hendrik Behrens", email = "hendrik.behrens@gmail.com" }
 ]
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "Flask==2.2.5",
     "jinja2==3.1.6",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{38,39,3.10,3.11,3.12,3.13}
+envlist = py{3.10,3.11,3.12,3.13}
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
It's end of life:

https://endoflife.date/python

And is blocking dependabot pr https://github.com/HBehrens/puncover/pull/142
