### PR TITLE
Fix - call unused json export function to report all symbol 

### DIFF
--- a/puncover/collector.py
+++ b/puncover/collector.py
@@ -785,6 +785,8 @@ class Collector:
                     "type",
                     "size",
                     "called_from_other_file",
+                    "calls_float_function",
+                    "performs_indirect_call",  # TODO add for manual resolution
                     "stack_size",
                     "stack_qualifiers",
                 ]:
@@ -812,8 +814,6 @@ class Collector:
                         callexs += [call]
                     non_circular_sym[sym_ele] = callexs
                 elif sym_ele in [
-                    "calls_float_function",
-                    "performs_indirect_call",  # TODO add for manual resolution
                     "next_function",
                     "prev_function",
                     "path",

--- a/puncover/collector.py
+++ b/puncover/collector.py
@@ -769,7 +769,7 @@ class Collector:
         self.user_defined_stack_report = report_max_map
         return report_max_map
 
-    def export_to_json(self, feature_tag, export_json_path):
+    def prepare_report_for_json_export(self, export_json_data):
         fn_symbols = []
         var_symbols = []
         if not self.symbols_by_qualified_name:
@@ -779,7 +779,6 @@ class Collector:
             # and memory explodes into 10's of GB's serializing it so make
             # symbols non-circular before serializing them to the database
             non_circular_sym = {}
-            filepath = "NONE"
             for sym_ele in sym.keys():
                 if sym_ele in [
                     "line",
@@ -801,7 +800,7 @@ class Collector:
                 elif sym_ele == "display_name":
                     non_circular_sym["name"] = sym[sym_ele]
                 elif sym_ele == "file":
-                    # TODO why is /-root missing, handle windows...
+                    # TODO why is /-root missing and handle windows paths...
                     filepath = "/" + str(sym["file"]["path"])
                     non_circular_sym[sym_ele] = filepath
                 elif sym_ele in ["callees"]:
@@ -812,7 +811,17 @@ class Collector:
                         call = {"from": from_addr, "to": to_addr, "dynamic": False}
                         callexs += [call]
                     non_circular_sym[sym_ele] = callexs
-                elif sym_ele in ["calls_float_function", "next_function", "prev_function", "path"]:
+                elif sym_ele in [
+                    "calls_float_function",
+                    "performs_indirect_call",  # TODO add for manual resolution
+                    "next_function",
+                    "prev_function",
+                    "path",
+                    "callers",
+                    "base_file",
+                    "deepest_callee_tree",
+                    "deepest_caller_tree",
+                ]:
                     # todo nothing?
                     pass
                 else:
@@ -822,5 +831,5 @@ class Collector:
             non_circular_sym.pop("type")
             symbols += [non_circular_sym]
         # if file exist
-        export_json_path[feature_tag]["functions"] = fn_symbols
-        export_json_path[feature_tag]["variables"] = var_symbols
+        export_json_data["functions"] = fn_symbols
+        export_json_data["variables"] = var_symbols

--- a/puncover/puncover.py
+++ b/puncover/puncover.py
@@ -198,7 +198,7 @@ def main():
                     args.report_max_static_stack_usage, args.report_type
                 )
             )
-
+        builder.collector.prepare_report_for_json_export(tag_data)
         export_json[args.report_tag] = tag_data
         with open(args.report_filename + ".json", "w") as f:
             json.dump(export_json, f, indent=4, ensure_ascii=False)

--- a/puncover/report_schema.json
+++ b/puncover/report_schema.json
@@ -121,6 +121,14 @@
           "title": "Called From Other File",
           "type": "boolean"
         },
+        "calls_float_function": {
+          "title": "Calls Float Function",
+          "type": "boolean"
+        },
+        "performs_indirect_call": {
+          "title": "Performs Indirect Call",
+          "type": "boolean"
+        },
         "stack_size": {
           "title": "Stack Size",
           "type": "integer"

--- a/puncover/report_schema.json
+++ b/puncover/report_schema.json
@@ -273,12 +273,98 @@
           ],
           "default": null,
           "title": "Functions"
+        },
+        "variables": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/VariableSymbol"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Variables"
         }
       },
       "required": [
         "timestamp"
       ],
       "title": "TagEntry",
+      "type": "object"
+    },
+    "VariableSymbol": {
+      "properties": {
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "file": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "File"
+        },
+        "line": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Line"
+        },
+        "address": {
+          "title": "Address",
+          "type": "integer"
+        },
+        "section_index": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Section Index"
+        },
+        "size": {
+          "title": "Size",
+          "type": "integer"
+        },
+        "type": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Type"
+        }
+      },
+      "required": [
+        "name",
+        "address",
+        "size"
+      ],
+      "title": "VariableSymbol",
       "type": "object"
     }
   },

--- a/puncover/report_schema.json
+++ b/puncover/report_schema.json
@@ -67,16 +67,8 @@
           "type": "array"
         },
         "max_stack_size": {
-          "anyOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Max Stack Size"
+          "title": "Max Stack Size",
+          "type": "integer"
         }
       },
       "required": [
@@ -93,141 +85,61 @@
           "type": "string"
         },
         "file": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "File"
+          "title": "File",
+          "type": "string"
         },
         "line": {
-          "anyOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Line"
+          "title": "Line",
+          "type": "integer"
         },
         "address": {
           "title": "Address",
           "type": "integer"
         },
         "section_index": {
-          "anyOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Section Index"
+          "title": "Section Index",
+          "type": "integer"
         },
         "size": {
           "title": "Size",
           "type": "integer"
         },
         "callers": {
-          "anyOf": [
-            {
-              "items": {
-                "$ref": "#/$defs/FunctionCall"
-              },
-              "type": "array"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Callers"
+          "items": {
+            "$ref": "#/$defs/FunctionCall"
+          },
+          "title": "Callers",
+          "type": "array"
         },
         "callees": {
-          "anyOf": [
-            {
-              "items": {
-                "$ref": "#/$defs/FunctionCall"
-              },
-              "type": "array"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Callees"
+          "items": {
+            "$ref": "#/$defs/FunctionCall"
+          },
+          "title": "Callees",
+          "type": "array"
         },
         "called_from_other_file": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Called From Other File"
+          "title": "Called From Other File",
+          "type": "boolean"
         },
         "stack_size": {
-          "anyOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Stack Size"
+          "title": "Stack Size",
+          "type": "integer"
         },
         "stack_qualifiers": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Stack Qualifiers"
+          "title": "Stack Qualifiers",
+          "type": "string"
         },
         "disasm": {
-          "anyOf": [
-            {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Disasm"
+          "items": {
+            "type": "string"
+          },
+          "title": "Disasm",
+          "type": "array"
         },
         "asm": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Asm"
+          "title": "Asm",
+          "type": "string"
         }
       },
       "required": [
@@ -245,49 +157,25 @@
           "type": "string"
         },
         "stack_report": {
-          "anyOf": [
-            {
-              "additionalProperties": {
-                "$ref": "#/$defs/FunctionStackReport"
-              },
-              "type": "object"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Stack Report"
+          "additionalProperties": {
+            "$ref": "#/$defs/FunctionStackReport"
+          },
+          "title": "Stack Report",
+          "type": "object"
         },
         "functions": {
-          "anyOf": [
-            {
-              "items": {
-                "$ref": "#/$defs/FunctionSymbol"
-              },
-              "type": "array"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Functions"
+          "items": {
+            "$ref": "#/$defs/FunctionSymbol"
+          },
+          "title": "Functions",
+          "type": "array"
         },
         "variables": {
-          "anyOf": [
-            {
-              "items": {
-                "$ref": "#/$defs/VariableSymbol"
-              },
-              "type": "array"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Variables"
+          "items": {
+            "$ref": "#/$defs/VariableSymbol"
+          },
+          "title": "Variables",
+          "type": "array"
         }
       },
       "required": [
@@ -303,60 +191,28 @@
           "type": "string"
         },
         "file": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "File"
+          "title": "File",
+          "type": "string"
         },
         "line": {
-          "anyOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Line"
+          "title": "Line",
+          "type": "integer"
         },
         "address": {
           "title": "Address",
           "type": "integer"
         },
         "section_index": {
-          "anyOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Section Index"
+          "title": "Section Index",
+          "type": "integer"
         },
         "size": {
           "title": "Size",
           "type": "integer"
         },
         "type": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Type"
+          "title": "Type",
+          "type": "string"
         }
       },
       "required": [

--- a/puncover/report_schema.json
+++ b/puncover/report_schema.json
@@ -47,7 +47,6 @@
       },
       "required": [
         "from",
-        "to",
         "dynamic"
       ],
       "title": "FunctionCall",

--- a/puncover/report_schema.json
+++ b/puncover/report_schema.json
@@ -30,6 +30,29 @@
       "title": "CallFrame",
       "type": "object"
     },
+    "FunctionCall": {
+      "properties": {
+        "from": {
+          "title": "From",
+          "type": "integer"
+        },
+        "to": {
+          "title": "To",
+          "type": "integer"
+        },
+        "dynamic": {
+          "title": "Dynamic",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "from",
+        "to",
+        "dynamic"
+      ],
+      "title": "FunctionCall",
+      "type": "object"
+    },
     "FunctionStackReport": {
       "properties": {
         "max_static_stack_size": {
@@ -63,6 +86,158 @@
       "title": "FunctionStackReport",
       "type": "object"
     },
+    "FunctionSymbol": {
+      "properties": {
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "file": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "File"
+        },
+        "line": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Line"
+        },
+        "address": {
+          "title": "Address",
+          "type": "integer"
+        },
+        "section_index": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Section Index"
+        },
+        "size": {
+          "title": "Size",
+          "type": "integer"
+        },
+        "callers": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/FunctionCall"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Callers"
+        },
+        "callees": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/FunctionCall"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Callees"
+        },
+        "called_from_other_file": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Called From Other File"
+        },
+        "stack_size": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Stack Size"
+        },
+        "stack_qualifiers": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Stack Qualifiers"
+        },
+        "disasm": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Disasm"
+        },
+        "asm": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Asm"
+        }
+      },
+      "required": [
+        "name",
+        "address",
+        "size"
+      ],
+      "title": "FunctionSymbol",
+      "type": "object"
+    },
     "TagEntry": {
       "properties": {
         "timestamp": {
@@ -83,6 +258,21 @@
           ],
           "default": null,
           "title": "Stack Report"
+        },
+        "functions": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/FunctionSymbol"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Functions"
         }
       },
       "required": [
@@ -97,5 +287,6 @@
   },
   "description": "Top-level report: keys are report tags, values are tagged run entries.",
   "title": "Report",
-  "type": "object"
+  "type": "object",
+  "$schema": "https://json-schema.org/draft/2020-12/schema"
 }

--- a/puncover/report_schema.py
+++ b/puncover/report_schema.py
@@ -54,10 +54,21 @@ class FunctionSymbol(BaseModel):
     asm: str | None = None
 
 
+class VariableSymbol(BaseModel):
+    name: str
+    file: str | None = None
+    line: int | None = None
+    address: int
+    section_index: int | None = None
+    size: int
+    type: str | None = None
+
+
 class TagEntry(BaseModel):
     timestamp: str
     stack_report: dict[str, FunctionStackReport] | None = None
     functions: list[FunctionSymbol] | None = None
+    variables: list[VariableSymbol] | None = None
 
 
 class Report(RootModel[dict[str, TagEntry]]):

--- a/puncover/report_schema.py
+++ b/puncover/report_schema.py
@@ -35,7 +35,7 @@ class FunctionStackReport(BaseModel):
 
 class FunctionCall(BaseModel):
     from_addr: int = Field(serialization_alias="from", alias="from", validation_alias="from")
-    to: int
+    to: int | MISSING = MISSING
     dynamic: bool
 
 

--- a/puncover/report_schema.py
+++ b/puncover/report_schema.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Union
 
 from pydantic import BaseModel, Field, RootModel
+from pydantic.experimental.missing_sentinel import MISSING
 from pydantic.json_schema import GenerateJsonSchema
 
 SCHEMA_PATH = Path(__file__).parent / "report_schema.json"
@@ -29,7 +30,7 @@ class CallFrame(BaseModel):
 class FunctionStackReport(BaseModel):
     max_static_stack_size: int
     call_stack: list[CallFrame]
-    max_stack_size: int | None = None  # only present when user supplied a limit via :::
+    max_stack_size: int | MISSING = MISSING  # only present when user supplied a limit via :::
 
 
 class FunctionCall(BaseModel):
@@ -40,35 +41,35 @@ class FunctionCall(BaseModel):
 
 class FunctionSymbol(BaseModel):
     name: str
-    file: str | None = None
-    line: int | None = None
+    file: str | MISSING = MISSING
+    line: int | MISSING = MISSING
     address: int
-    section_index: int | None = None
+    section_index: int | MISSING = MISSING
     size: int
-    callers: list[FunctionCall] | None = None
-    callees: list[FunctionCall] | None = None
-    called_from_other_file: bool | None = None
-    stack_size: int | None = None
-    stack_qualifiers: str | None = None
-    disasm: list[str] | None = None
-    asm: str | None = None
+    callers: list[FunctionCall] | MISSING = MISSING
+    callees: list[FunctionCall] | MISSING = MISSING
+    called_from_other_file: bool | MISSING = MISSING
+    stack_size: int | MISSING = MISSING
+    stack_qualifiers: str | MISSING = MISSING
+    disasm: list[str] | MISSING = MISSING
+    asm: str | MISSING = MISSING
 
 
 class VariableSymbol(BaseModel):
     name: str
-    file: str | None = None
-    line: int | None = None
+    file: str | MISSING = MISSING
+    line: int | MISSING = MISSING
     address: int
-    section_index: int | None = None
+    section_index: int | MISSING = MISSING
     size: int
-    type: str | None = None
+    type: str | MISSING = MISSING
 
 
 class TagEntry(BaseModel):
     timestamp: str
-    stack_report: dict[str, FunctionStackReport] | None = None
-    functions: list[FunctionSymbol] | None = None
-    variables: list[VariableSymbol] | None = None
+    stack_report: dict[str, FunctionStackReport] | MISSING = MISSING
+    functions: list[FunctionSymbol] | MISSING = MISSING
+    variables: list[VariableSymbol] | MISSING = MISSING
 
 
 class Report(RootModel[dict[str, TagEntry]]):

--- a/puncover/report_schema.py
+++ b/puncover/report_schema.py
@@ -49,6 +49,8 @@ class FunctionSymbol(BaseModel):
     callers: list[FunctionCall] | MISSING = MISSING
     callees: list[FunctionCall] | MISSING = MISSING
     called_from_other_file: bool | MISSING = MISSING
+    calls_float_function: bool | MISSING = MISSING
+    performs_indirect_call: bool | MISSING = MISSING
     stack_size: int | MISSING = MISSING
     stack_qualifiers: str | MISSING = MISSING
     disasm: list[str] | MISSING = MISSING

--- a/puncover/report_schema.py
+++ b/puncover/report_schema.py
@@ -14,7 +14,8 @@ import json
 from pathlib import Path
 from typing import Union
 
-from pydantic import BaseModel, RootModel
+from pydantic import BaseModel, Field, RootModel
+from pydantic.json_schema import GenerateJsonSchema
 
 SCHEMA_PATH = Path(__file__).parent / "report_schema.json"
 
@@ -31,9 +32,32 @@ class FunctionStackReport(BaseModel):
     max_stack_size: int | None = None  # only present when user supplied a limit via :::
 
 
+class FunctionCall(BaseModel):
+    from_addr: int = Field(serialization_alias="from", alias="from", validation_alias="from")
+    to: int
+    dynamic: bool
+
+
+class FunctionSymbol(BaseModel):
+    name: str
+    file: str | None = None
+    line: int | None = None
+    address: int
+    section_index: int | None = None
+    size: int
+    callers: list[FunctionCall] | None = None
+    callees: list[FunctionCall] | None = None
+    called_from_other_file: bool | None = None
+    stack_size: int | None = None
+    stack_qualifiers: str | None = None
+    disasm: list[str] | None = None
+    asm: str | None = None
+
+
 class TagEntry(BaseModel):
     timestamp: str
     stack_report: dict[str, FunctionStackReport] | None = None
+    functions: list[FunctionSymbol] | None = None
 
 
 class Report(RootModel[dict[str, TagEntry]]):
@@ -41,7 +65,9 @@ class Report(RootModel[dict[str, TagEntry]]):
 
 
 def generate_schema() -> dict:
-    return Report.model_json_schema()
+    schema = Report.model_json_schema()
+    schema["$schema"] = GenerateJsonSchema.schema_dialect
+    return schema
 
 
 def write_schema(path: Path = SCHEMA_PATH) -> None:


### PR DESCRIPTION
- add the call to prepare_report_for_json_export adding the function and variable symbols to the tag_dat in puncover.py‎
- add function and variable symbols schema as pydantic models