### PR TITLE
Feature - Improve UI+docs for worst case stack scenario found

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ You can also use `uvx` to run the script without installing globally:
 uvx puncover project.elf
 ```
 
+### Analysing stack usage
+
+In order to evaluate the stack usage of function and call trees, it is necessary to build with the `-fstack-usage` flag.
+
+This tells GCC to generate stack usage files (.su) for each compilation unit.
+
+For puncover to evaluate these .su files the `--build_dir` option needs to point to the build folder of the firmware.
+
 ### Report export and non-interactive usage
 
 To monitor firmware changes in CI it can be useful to run puncover and save a

--- a/puncover/backtrace_helper.py
+++ b/puncover/backtrace_helper.py
@@ -37,17 +37,23 @@ class BacktraceHelper:
             if c not in visited:
                 candidate = self.deepest_call_tree(c, list_attribute, cache_attribute, visited)
                 # mark a functions deepest call incomplete when calls or stack sizes of callpaths are unknown
-                if collector.PERFORMS_INDIRECT_CALL in candidate and candidate[collector.PERFORMS_INDIRECT_CALL]:
-                    f[collector.UNRESOLVED_CALLS_IN_CALL_TREE] = True
-                if collector.STACK_SIZE not in candidate:
-                    f[collector.MISSING_STACKSIZE_IN_CALL_TREE] = True
-                if collector.STACK_QUALIFIERS in candidate:
-                    stack_qualifiers = candidate[collector.STACK_QUALIFIERS]
-                    if stack_qualifiers in "dynamic":
-                        f[collector.UNBOUND_STACKSIZE_IN_CALL_TREE] = True
-                    # TODO with dynamic, bounded then we would need to evaluate call addresse -
-                    # since there are more then on point in the function maybe in-between calls
-                    # were allocation happens...
+                if collector.PERFORMS_INDIRECT_CALL in c and c[collector.PERFORMS_INDIRECT_CALL]:
+                    if collector.UNRESOLVED_CALLS_IN_CALL_TREE not in f:
+                        f[collector.UNRESOLVED_CALLS_IN_CALL_TREE] = 1
+                    else:
+                        f[collector.UNRESOLVED_CALLS_IN_CALL_TREE] += 1
+                if collector.STACK_SIZE not in c:
+                    if collector.MISSING_STACKSIZE_IN_CALL_TREE not in f:
+                        f[collector.MISSING_STACKSIZE_IN_CALL_TREE] = 1
+                    else:
+                        f[collector.MISSING_STACKSIZE_IN_CALL_TREE] += 1
+                if collector.STACK_QUALIFIERS in c and c[collector.STACK_QUALIFIERS] == "dynamic":
+                    # TODO with dynamic,bounded then we would need to evaluate call addresse within the fuction -
+                    # since there are more then on point in the function maybe in-between calls were allocation happens...
+                    if collector.UNBOUND_STACKSIZE_IN_CALL_TREE not in f:
+                        f[collector.UNBOUND_STACKSIZE_IN_CALL_TREE] = 1
+                    else:
+                        f[collector.UNBOUND_STACKSIZE_IN_CALL_TREE] += 1
                 if candidate[0] > result[0]:
                     result = candidate
 

--- a/puncover/backtrace_helper.py
+++ b/puncover/backtrace_helper.py
@@ -36,6 +36,18 @@ class BacktraceHelper:
         for c in f[list_attribute]:
             if c not in visited:
                 candidate = self.deepest_call_tree(c, list_attribute, cache_attribute, visited)
+                # mark a functions deepest call incomplete when calls or stack sizes of callpaths are unknown
+                if collector.PERFORMS_INDIRECT_CALL in candidate and candidate[collector.PERFORMS_INDIRECT_CALL]:
+                    f[collector.UNRESOLVED_CALLS_IN_CALL_TREE] = True
+                if collector.STACK_SIZE not in candidate:
+                    f[collector.MISSING_STACKSIZE_IN_CALL_TREE] = True
+                if collector.STACK_QUALIFIERS in candidate:
+                    stack_qualifiers = candidate[collector.STACK_QUALIFIERS]
+                    if stack_qualifiers in "dynamic":
+                        f[collector.UNBOUND_STACKSIZE_IN_CALL_TREE] = True
+                    # TODO with dynamic, bounded then we would need to evaluate call addresse -
+                    # since there are more then on point in the function maybe in-between calls
+                    # were allocation happens...
                 if candidate[0] > result[0]:
                     result = candidate
 

--- a/puncover/collector.py
+++ b/puncover/collector.py
@@ -35,6 +35,12 @@ COLLAPSED_SUB_FOLDERS = "collapsed_sub_folders"
 CALLEES = "callees"
 CALLERS = "callers"
 
+CALLS_FLOAT_FUNCTION = "calls_float_function"
+PERFORMS_INDIRECT_CALL = "performs_indirect_call"
+UNRESOLVED_CALLS_IN_CALL_TREE = "unresolved_calls_in_call_tree"
+MISSING_STACKSIZE_IN_CALL_TREE = "missing_stacksize_in_call_tree"
+UNBOUND_STACKSIZE_IN_CALL_TREE = "unbound_stacksize_in_call_tree"
+
 DEEPEST_CALLEE_TREE = "deepest_callee_tree"
 DEEPEST_CALLER_TREE = "deepest_caller_tree"
 
@@ -470,7 +476,7 @@ class Collector:
 
         match = self.gcc_tools.indirect_call_pattern.match(line)
         if match:
-            function["performs_indirect_call"] = True
+            function[PERFORMS_INDIRECT_CALL] = True
             return True
 
         return False
@@ -682,17 +688,17 @@ class Collector:
         float_functions = [f for f in self.all_functions() if is_float_function_name(f[NAME])]
         for f in self.all_functions():
             callees = f[CALLEES]
-            f["calls_float_function"] = any([ff in callees for ff in float_functions])
+            f[CALLS_FLOAT_FUNCTION] = any([ff in callees for ff in float_functions])
 
         for file in self.all_files():
-            file["calls_float_function"] = any([f["calls_float_function"] for f in file[FUNCTIONS]])
+            file[CALLS_FLOAT_FUNCTION] = any([f[CALLS_FLOAT_FUNCTION] for f in file[FUNCTIONS]])
 
         def folder_calls_float_function(folder):
-            result = any([f["calls_float_function"] for f in folder[FILES]])
+            result = any([f[CALLS_FLOAT_FUNCTION] for f in folder[FILES]])
             for sub_folder in folder[SUB_FOLDERS]:
                 if folder_calls_float_function(sub_folder):
                     result = True
-            folder["calls_float_function"] = result
+            folder[CALLS_FLOAT_FUNCTION] = result
             return result
 
         for folder in self.root_folders():

--- a/puncover/collector.py
+++ b/puncover/collector.py
@@ -348,7 +348,15 @@ class Collector:
                 symbol[STACK_QUALIFIERS] = stack_qualifier
                 return True
 
-        warning("Couldn't find symbol for %s:%d:%s" % (base_file_name, line, symbol_name))
+        # when a i.e. a function is compiled into the object file, but unused
+        # then during the complilation it is mentioned in the .su file,
+        # later during linking the function may be optimized out and not get into the final .elf
+        # TODO this causes many warnings for fw optimizing during linking,
+        # as long as each function in the ELF gets a .su value maybe this does not need to
+        # generate a warning for symbols not in the ELF, which are mentioned here?
+        warning(
+            f"Couldn't find symbol for {base_file_name}:{line}:{symbol_name}) - may be optimized out?"
+        )
         return False
 
     windows_path_pattern = re.compile(r"^([a-zA-Z]+)(:)(\\)(.+)$")

--- a/puncover/templates/symbol.html.jinja
+++ b/puncover/templates/symbol.html.jinja
@@ -74,7 +74,46 @@
     {% endif %}
 
     {% if (symbol.deepest_caller_tree[1] | length > 1) or (symbol.deepest_callee_tree[1] | length > 1) %}
-        <h1>Stack Worst-Case Scenarios</h1>
+        <h1>Found scenario for worst-case stack usage</h1>
+        Be aware: This is the best estimate on the given information.
+        Real stack usage might be higher, due to many reasons (like context changes into interrupts).
+
+        {% if symbol.unresolved_calls_in_call_tree %}
+            <div class="alert alert-warning" role="alert">
+                WARNING: There
+                {% if symbol.unresolved_calls_in_call_tree == 1 %}
+                is {{symbol.unresolved_calls_in_call_tree}} function
+                {% else %}
+                are {{symbol.unresolved_calls_in_call_tree}} functions
+                {% endif %}
+                with dynamic calls, and cannot automatically resolved at compile time from the ELF. <br/>
+                The given scenario cannot accurately be estimated without these, since the call tree is incomplete.
+            </div>
+        {% endif %}
+        {% if symbol.missing_stacksize_in_call_tree %}
+            <div class="alert alert-warning" role="alert">
+                WARNING: There
+                {% if symbol.missing_stacksize_in_call_tree == 1 %}
+                is {{symbol.missing_stacksize_in_call_tree}} function
+                {% else %}
+                are {{symbol.missing_stacksize_in_call_tree}} functions
+                {% endif %}
+                with missing stack sizes in the symbol dataset. <br/>
+                The given scenario cannot accurately be estimated without these functions stack-sizes.
+            </div>
+        {% endif %}
+        {% if symbol.unbound_stacksize_in_call_tree %}
+            <div class="alert alert-warning" role="alert">
+                WARNING: There
+                {% if symbol.unbound_stacksize_in_call_tree == 1 %}
+                is {{symbol.unbound_stacksize_in_call_tree}} function
+                {% else %}
+                are {{symbol.unbound_stacksize_in_call_tree}} functions
+                {% endif %}
+                with dynamic stack size. <br/>
+                The given scenario cannot accurately be estimated without more precise constraints for these functions.
+            </div>
+        {% endif %}
         {% if symbol.deepest_callee_tree[1] | length > 1 %}
         {{ lists.function_stats(symbol.deepest_callee_tree[1][1:] | reverse | list, stack_base=symbol.deepest_caller_tree[1]|symbol_stack_size) }}
         {% else %}

--- a/puncover/templates/symbol.html.jinja
+++ b/puncover/templates/symbol.html.jinja
@@ -86,7 +86,7 @@
                 {% else %}
                 are {{symbol.unresolved_calls_in_call_tree}} functions
                 {% endif %}
-                with dynamic calls, and cannot automatically resolved at compile time from the ELF. <br/>
+                with dynamic calls, and cannot be automatically resolved at compile time from the ELF. <br/>
                 The given scenario cannot accurately be estimated without these, since the call tree is incomplete.
             </div>
         {% endif %}


### PR DESCRIPTION
- [x] add instructions to README on how to enable and use stack estimation
- [x] add warning / explain uncertainties around missing calls and stack sizes

Here is a demo, of snprintf from the [cannectivity](https://github.com/CANnectivity/cannectivity) firmware based on zephyr RTOS, that has both indirect calls and missing stack size in its callees:

<img width="1157" height="933" alt="image" src="https://github.com/user-attachments/assets/ed972008-5fec-4d94-8049-b620e6bda707" />

Happy to discuss the feature. When I discussed with people that puncover can evaluate .su files on the firmware callgraph "how does it work, it did not give me stack sizes?!" and "is the reported size reliable?" where common answers. This proposal tries to answer this more clearly. Also, please change the wording if it sounds of, I am no english native :upside_down_face: 