### PR TITLE
Fix - add missing nm letter-mapping for weakly linked symbols and functions

### DIFF
--- a/puncover/collector.py
+++ b/puncover/collector.py
@@ -181,9 +181,11 @@ class Collector:
         types = {
             "A": TYPE_FUNCTION,
             "T": TYPE_FUNCTION,
+            "W": TYPE_FUNCTION,
             "D": TYPE_VARIABLE,
             "B": TYPE_VARIABLE,
             "R": TYPE_VARIABLE,
+            "V": TYPE_VARIABLE,
         }
 
         self.add_symbol(


### PR DESCRIPTION
From the 3d printer firmware I looked at all W's were functions/methods and V's variables/members.
That was not evident for me from the wording in `info nm` ...

>      ‘V’
>      ‘v’
>           The symbol is a weak object.  When a weak defined symbol is
>           linked with a normal defined symbol, the normal defined symbol
>           is used with no error.  When a weak undefined symbol is linked
>           and the symbol is not defined, the value of the weak symbol
>           becomes zero with no error.  On some systems, uppercase
>           indicates that a default value has been specified.
> 
>      ‘W’
>      ‘w’
>           The symbol is a weak symbol that has not been specifically
>           tagged as a weak object symbol.  When a weak defined symbol is
>           linked with a normal defined symbol, the normal defined symbol
>           is used with no error.  When a weak undefined symbol is linked
>           and the symbol is not defined, the value of the symbol is
>           determined in a system-specific manner without error.  On some
>           systems, uppercase indicates that a default value has been
>           specified.

So just confirming by what I observed by what gcc did on this firmware.

Looking at the nm output directly and how many symbols this affected in this example:

`nm -Sl firmware.elf | cut -d ' ' -f3 | sort | uniq -cd | sort -n`

>      43 V
>      77 W
>     205 B
>     422 $t
>     716 b
>     720 $d
>     913 R
>    2331 r
>    5555 T
>  11421 t

$d and $t is some alignment thing from what I saw.  So 43 variables and 77 functions or <1% symbols missed their type :)


