### PR TITLE
Fix crash in url_for_symbol

### DIFF
--- a/puncover/renderers.py
+++ b/puncover/renderers.py
@@ -311,7 +311,8 @@ class HTMLRenderer(View):
         return result_str + ("?" + query_string if query_string else "")
 
     def url_for_symbol(self, value):
-        if value[collector.TYPE] in [collector.TYPE_FUNCTION]:
+        symbol_type = value.get(collector.TYPE, None)
+        if symbol_type in [collector.TYPE_FUNCTION]:
             return self.url_for("path", path=self.collector.qualified_symbol_name(value))
 
         # file or folder


### PR DESCRIPTION
puncover assumes every symbol has type, but some parsed symbols don’t. Handle unknown types gracefully.