### PR TITLE
Fix crashes, correct cyclic worst-case stack, and improve call-tree warnings

### DIFF
--- a/puncover/backtrace_helper.py
+++ b/puncover/backtrace_helper.py
@@ -26,40 +26,71 @@ class BacktraceHelper:
         return self.derive_functions_symbols_pattern.sub(f, text)
 
     def deepest_call_tree(self, f, list_attribute, cache_attribute, visited=None):
-        # TODO: find strongly connected components and count cycles correctly
+        result, _ = self._deepest_call_tree(f, list_attribute, cache_attribute, visited)
+        return result
+
+    def _deepest_call_tree(self, f, list_attribute, cache_attribute, visited=None):
+        # Returns (result, hit_cycle). The deepest call tree is the longest
+        # *simple* path (each function counted once); cycles are broken via the
+        # `visited` set.
+        #
+        # `hit_cycle` is True when a back-edge to a node already on the current
+        # path had to be dropped. Such a result is PATH-DEPENDENT, so it must not
+        # be memoized: caching it under one start node and reusing it from another
+        # is exactly what produced order-dependent, under-counted worst-case
+        # stacks (e.g. a function inside a mutual-recursion cycle reporting only
+        # its own frame). Acyclic results do not depend on the path, so they are
+        # cached as before and the traversal stays fast on the common case.
         if cache_attribute in f:
-            return f[cache_attribute]
+            return f[cache_attribute], False
 
         visited = [f] + (visited if visited else [])
         result = (0, [])
+        hit_cycle = False
 
         for c in f[list_attribute]:
-            if c not in visited:
-                candidate = self.deepest_call_tree(c, list_attribute, cache_attribute, visited)
-                # mark a functions deepest call incomplete when calls or stack sizes of callpaths are unknown
-                if collector.PERFORMS_INDIRECT_CALL in c and c[collector.PERFORMS_INDIRECT_CALL]:
-                    if collector.UNRESOLVED_CALLS_IN_CALL_TREE not in f:
-                        f[collector.UNRESOLVED_CALLS_IN_CALL_TREE] = 1
-                    else:
-                        f[collector.UNRESOLVED_CALLS_IN_CALL_TREE] += 1
-                if collector.STACK_SIZE not in c:
-                    if collector.MISSING_STACKSIZE_IN_CALL_TREE not in f:
-                        f[collector.MISSING_STACKSIZE_IN_CALL_TREE] = 1
-                    else:
-                        f[collector.MISSING_STACKSIZE_IN_CALL_TREE] += 1
-                if collector.STACK_QUALIFIERS in c and c[collector.STACK_QUALIFIERS] == "dynamic":
-                    # TODO with dynamic,bounded then we would need to evaluate call addresse within the fuction -
-                    # since there are more then on point in the function maybe in-between calls were allocation happens...
-                    if collector.UNBOUND_STACKSIZE_IN_CALL_TREE not in f:
-                        f[collector.UNBOUND_STACKSIZE_IN_CALL_TREE] = 1
-                    else:
-                        f[collector.UNBOUND_STACKSIZE_IN_CALL_TREE] += 1
-                if candidate[0] > result[0]:
-                    result = candidate
+            if c in visited:
+                hit_cycle = True
+                continue
+            candidate, child_hit_cycle = self._deepest_call_tree(
+                c, list_attribute, cache_attribute, visited
+            )
+            hit_cycle = hit_cycle or child_hit_cycle
+            if candidate[0] > result[0]:
+                result = candidate
 
         result = (result[0] + f.get(collector.STACK_SIZE, 0), [f] + result[1])
-        f[cache_attribute] = result
-        return result
+        if not hit_cycle:
+            f[cache_attribute] = result
+        return result, hit_cycle
+
+    def annotate_call_tree_flags(self):
+        """Set the per-function call-tree warning flags (unresolved indirect
+        calls, missing stack sizes, dynamic/unbound frames).
+
+        Kept separate from the memoized deepest_call_tree on purpose: cyclic
+        results are intentionally not cached (see _deepest_call_tree), so folding
+        this bookkeeping into the traversal would double-count whenever a node is
+        re-expanded. This pass runs once per function and is order-independent.
+        Semantics match the historical behaviour: a function is flagged once for
+        each direct callee/caller that performs an indirect call, lacks a stack
+        size, or has a dynamic stack frame.
+        """
+        for f in self.collector.all_functions():
+            unresolved = missing = unbound = 0
+            for c in f.get(collector.CALLEES, []) + f.get(collector.CALLERS, []):
+                if c.get(collector.PERFORMS_INDIRECT_CALL):
+                    unresolved += 1
+                if collector.STACK_SIZE not in c:
+                    missing += 1
+                if c.get(collector.STACK_QUALIFIERS) == "dynamic":
+                    unbound += 1
+            if unresolved:
+                f[collector.UNRESOLVED_CALLS_IN_CALL_TREE] = unresolved
+            if missing:
+                f[collector.MISSING_STACKSIZE_IN_CALL_TREE] = missing
+            if unbound:
+                f[collector.UNBOUND_STACKSIZE_IN_CALL_TREE] = unbound
 
     def deepest_callee_tree(self, f):
         return self.deepest_call_tree(f, collector.CALLEES, collector.DEEPEST_CALLEE_TREE)

--- a/puncover/backtrace_helper.py
+++ b/puncover/backtrace_helper.py
@@ -65,32 +65,83 @@ class BacktraceHelper:
         return result, hit_cycle
 
     def annotate_call_tree_flags(self):
-        """Set the per-function call-tree warning flags (unresolved indirect
-        calls, missing stack sizes, dynamic/unbound frames).
+        """Set the per-function call-tree warning flags: how many functions
+        anywhere in the call tree perform an indirect call, lack a stack size, or
+        have a dynamic stack frame, plus a recursion flag. The tree is the union
+        of everything reachable via callees and via callers (the worst-case page
+        shows both directions), deduplicated, so a problem deep in the tree warns
+        every ancestor -- not just the direct parent.
 
-        Kept separate from the memoized deepest_call_tree on purpose: cyclic
-        results are intentionally not cached (see _deepest_call_tree), so folding
-        this bookkeeping into the traversal would double-count whenever a node is
-        re-expanded. This pass runs once per function and is order-independent.
-        Semantics match the historical behaviour: a function is flagged once for
-        each direct callee/caller that performs an indirect call, lacks a stack
-        size, or has a dynamic stack frame.
+        Kept out of the memoised deepest_call_tree on purpose: cyclic results are
+        intentionally not cached there, so counting during that traversal would
+        double-count on re-expansion. This pass is order-independent.
         """
+        callee_recursion = {}
+        caller_recursion = {}
         for f in self.collector.all_functions():
-            unresolved = missing = unbound = 0
-            for c in f.get(collector.CALLEES, []) + f.get(collector.CALLERS, []):
-                if c.get(collector.PERFORMS_INDIRECT_CALL):
-                    unresolved += 1
-                if collector.STACK_SIZE not in c:
-                    missing += 1
-                if c.get(collector.STACK_QUALIFIERS) == "dynamic":
-                    unbound += 1
+            tree = {}
+            tree.update(self._reachable(f, collector.CALLEES))
+            tree.update(self._reachable(f, collector.CALLERS))
+            functions = tree.values()
+            unresolved = sum(1 for c in functions if c.get(collector.PERFORMS_INDIRECT_CALL))
+            missing = sum(1 for c in functions if collector.STACK_SIZE not in c)
+            unbound = sum(1 for c in functions if c.get(collector.STACK_QUALIFIERS) == "dynamic")
             if unresolved:
                 f[collector.UNRESOLVED_CALLS_IN_CALL_TREE] = unresolved
             if missing:
                 f[collector.MISSING_STACKSIZE_IN_CALL_TREE] = missing
             if unbound:
                 f[collector.UNBOUND_STACKSIZE_IN_CALL_TREE] = unbound
+            # A call tree that contains recursion (direct self-calls or a mutual
+            # cycle) cannot have its stack bounded statically, so flag it -- the
+            # deepest-path figure is then a lower bound, not an upper bound.
+            if self._reaches_recursion(
+                f, collector.CALLEES, callee_recursion
+            ) or self._reaches_recursion(f, collector.CALLERS, caller_recursion):
+                f[collector.RECURSION_IN_CALL_TREE] = True
+
+    def _reachable(self, f, list_attribute):
+        """All functions reachable from f along ``list_attribute`` (its whole
+        callee- or caller-tree), as an ``{id: function}`` map. f itself is
+        included only if it lies on a cycle. Iterative, cycle-safe BFS."""
+        seen = {}
+        stack = list(f.get(list_attribute, []))
+        while stack:
+            c = stack.pop()
+            cid = id(c)
+            if cid in seen:
+                continue
+            seen[cid] = c
+            stack.extend(c.get(list_attribute, []))
+        return seen
+
+    def _reaches_recursion(self, f, list_attribute, memo, on_stack=None):
+        """Whether f -- or anything reachable along ``list_attribute`` -- lies on
+        a cycle (mutual recursion) or is directly self-recursive. Unlike the
+        deepest path, "reaches a cycle" does not depend on how f was reached, so
+        it is safe to memoise across start nodes."""
+        key = id(f)
+        if key in memo:
+            return memo[key]
+        if f.get(collector.SELF_RECURSIVE):
+            memo[key] = True
+            return True
+        if on_stack is None:
+            on_stack = set()
+        on_stack.add(key)
+        result = False
+        for c in f[list_attribute]:
+            ck = id(c)
+            if (
+                ck in on_stack
+                or memo.get(ck)
+                or self._reaches_recursion(c, list_attribute, memo, on_stack)
+            ):
+                result = True
+                break
+        on_stack.discard(key)
+        memo[key] = result
+        return result
 
     def deepest_callee_tree(self, f):
         return self.deepest_call_tree(f, collector.CALLEES, collector.DEEPEST_CALLEE_TREE)

--- a/puncover/backtrace_helper.py
+++ b/puncover/backtrace_helper.py
@@ -6,6 +6,11 @@ from puncover import collector
 class BacktraceHelper:
     def __init__(self, collector):
         self.collector = collector
+        # Memo for deepest-tree results, kept OFF the symbol dicts on purpose:
+        # only acyclic (path-independent) results are stored here, so nothing
+        # cached is ever a cyclic, order-dependent value that could be wrongly
+        # reused for another start node.
+        self._deepest_memo = {}
 
     derive_functions_symbols_pattern = re.compile(r"\b(\w+)\b")
 
@@ -41,8 +46,9 @@ class BacktraceHelper:
         # stacks (e.g. a function inside a mutual-recursion cycle reporting only
         # its own frame). Acyclic results do not depend on the path, so they are
         # cached as before and the traversal stays fast on the common case.
-        if cache_attribute in f:
-            return f[cache_attribute], False
+        memo_key = (id(f), cache_attribute)
+        if memo_key in self._deepest_memo:
+            return self._deepest_memo[memo_key], False
 
         visited = [f] + (visited if visited else [])
         result = (0, [])
@@ -61,7 +67,7 @@ class BacktraceHelper:
 
         result = (result[0] + f.get(collector.STACK_SIZE, 0), [f] + result[1])
         if not hit_cycle:
-            f[cache_attribute] = result
+            self._deepest_memo[memo_key] = result
         return result, hit_cycle
 
     def annotate_call_tree_flags(self):
@@ -144,7 +150,13 @@ class BacktraceHelper:
         return result
 
     def deepest_callee_tree(self, f):
-        return self.deepest_call_tree(f, collector.CALLEES, collector.DEEPEST_CALLEE_TREE)
+        result = self.deepest_call_tree(f, collector.CALLEES, collector.DEEPEST_CALLEE_TREE)
+        # Always expose the deepest tree on the symbol, even when it contains a
+        # cycle: the template and the report read this key unconditionally.
+        f[collector.DEEPEST_CALLEE_TREE] = result
+        return result
 
     def deepest_caller_tree(self, f):
-        return self.deepest_call_tree(f, collector.CALLERS, collector.DEEPEST_CALLER_TREE)
+        result = self.deepest_call_tree(f, collector.CALLERS, collector.DEEPEST_CALLER_TREE)
+        f[collector.DEEPEST_CALLER_TREE] = result
+        return result

--- a/puncover/builders.py
+++ b/puncover/builders.py
@@ -44,6 +44,7 @@ class Builder:
         for f in self.collector.all_functions():
             self.backtrace_helper.deepest_callee_tree(f)
             self.backtrace_helper.deepest_caller_tree(f)
+        self.backtrace_helper.annotate_call_tree_flags()
 
 
 class ElfBuilder(Builder):

--- a/puncover/collector.py
+++ b/puncover/collector.py
@@ -40,6 +40,8 @@ PERFORMS_INDIRECT_CALL = "performs_indirect_call"
 UNRESOLVED_CALLS_IN_CALL_TREE = "unresolved_calls_in_call_tree"
 MISSING_STACKSIZE_IN_CALL_TREE = "missing_stacksize_in_call_tree"
 UNBOUND_STACKSIZE_IN_CALL_TREE = "unbound_stacksize_in_call_tree"
+SELF_RECURSIVE = "self_recursive"
+RECURSION_IN_CALL_TREE = "recursion_in_call_tree"
 
 DEEPEST_CALLEE_TREE = "deepest_callee_tree"
 DEEPEST_CALLER_TREE = "deepest_caller_tree"
@@ -446,15 +448,20 @@ class Collector:
                 symbol[ASM] = list([self.enhanced_assembly_line(line) for line in symbol[ASM]])
 
     def add_function_call(self, caller, callee):
-        if caller != callee:
-            if callee not in caller[CALLEES]:
-                caller[CALLEES].append(callee)
-            if caller not in callee[CALLERS]:
-                callee[CALLERS].append(caller)
-                caller_file = caller.get("file", None)
-                callee_file = callee.get("file", None)
-                if callee_file and caller_file and callee_file != caller_file:
-                    callee["called_from_other_file"] = True
+        if caller == callee:
+            # Self-edges are intentionally not added to the call graph, but record
+            # the direct recursion so the worst-case-stack analysis can flag it
+            # (otherwise a self-recursive function silently reports one frame).
+            caller[SELF_RECURSIVE] = True
+            return
+        if callee not in caller[CALLEES]:
+            caller[CALLEES].append(callee)
+        if caller not in callee[CALLERS]:
+            callee[CALLERS].append(caller)
+            caller_file = caller.get("file", None)
+            callee_file = callee.get("file", None)
+            if callee_file and caller_file and callee_file != caller_file:
+                callee["called_from_other_file"] = True
 
     def add_function_call_from_assembly_line(self, function, line):
         if "<" not in line:
@@ -841,8 +848,13 @@ class Collector:
                     "base_file",
                     "deepest_callee_tree",
                     "deepest_caller_tree",
+                    "unresolved_calls_in_call_tree",
+                    "missing_stacksize_in_call_tree",
+                    "unbound_stacksize_in_call_tree",
+                    "self_recursive",
+                    "recursion_in_call_tree",
                 ]:
-                    # todo nothing?
+                    # internal call-tree analysis flags; not part of the report schema
                     pass
                 else:
                     print("unknown key " + sym_ele)

--- a/puncover/collector.py
+++ b/puncover/collector.py
@@ -746,7 +746,11 @@ class Collector:
 
         report_max_map = {}
         for sym in self.symbols.values():
-            name = sym["display_name"]
+            # Only functions have call trees; a variable whose display_name
+            # matches a requested name would otherwise raise KeyError below.
+            if sym.get(TYPE) != TYPE_FUNCTION:
+                continue
+            name = sym.get(DISPLAY_NAME)
             if name not in function_names:
                 continue
 
@@ -842,10 +846,13 @@ class Collector:
                     pass
                 else:
                     print("unknown key " + sym_ele)
-            # add flatten symbol to list
-            symbols = fn_symbols if non_circular_sym["type"] == "function" else var_symbols
-            non_circular_sym.pop("type")
-            symbols += [non_circular_sym]
+            # add flattened symbol to the matching list. Some symbols have no
+            # TYPE (nm letters not in our map); skip them instead of raising.
+            sym_type = non_circular_sym.pop("type", None)
+            if sym_type == TYPE_FUNCTION:
+                fn_symbols.append(non_circular_sym)
+            elif sym_type == TYPE_VARIABLE:
+                var_symbols.append(non_circular_sym)
         # if file exist
         export_json_data["functions"] = fn_symbols
         export_json_data["variables"] = var_symbols

--- a/puncover/renderers.py
+++ b/puncover/renderers.py
@@ -311,7 +311,12 @@ class HTMLRenderer(View):
         return result_str + ("?" + query_string if query_string else "")
 
     def url_for_symbol(self, value):
-        if value[collector.TYPE] in [collector.TYPE_FUNCTION]:
+        # A breadcrumb passes folder=None for a file at the root of --src_root,
+        # and some symbols have no TYPE (nm letters not in our map); neither must
+        # raise (would be an HTTP 500). Render a plain, un-linked entry instead.
+        if value is None:
+            return ""
+        if value.get(collector.TYPE) in [collector.TYPE_FUNCTION]:
             return self.url_for("path", path=self.collector.qualified_symbol_name(value))
 
         # file or folder

--- a/puncover/templates/symbol.html.jinja
+++ b/puncover/templates/symbol.html.jinja
@@ -63,6 +63,14 @@
         </tbody>
     </table>
 
+    {% if symbol.recursion_in_call_tree %}
+    <div class="alert alert-warning" role="alert">
+        WARNING: this function's call tree contains recursion (direct or mutual).
+        Stack usage of a recursive call tree cannot be bounded statically, so any
+        worst-case figure shown below is a lower bound, not an upper bound.
+    </div>
+    {% endif %}
+
     {% if symbol.prev_function %}
     <pre><a href="{{ symbol.prev_function|symbol_url }}">{{ symbol.prev_function.display_name |e }} {{ '(%d)' % symbol.prev_function.size if symbol.prev_function.size}}</a></pre>
     {% endif %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "puncover"
 description = "Analyses C/C++ build output for code size, static variables, and stack usage."
-version = "0.8.0"
+version = "0.8.0+mod"
 authors = [
     { name = "Hendrik Behrens", email = "hendrik.behrens@gmail.com" }
 ]

--- a/tests/test_backtrace_helper.py
+++ b/tests/test_backtrace_helper.py
@@ -100,15 +100,28 @@ class TestBacktraceHelperTreeSizes(unittest.TestCase):
         actual = self.h.deepest_callee_tree(self.a)
         self.assertEqual(expected, actual)
 
-        expected = (10, [self.b])
+        # b -> a -> (b dropped as a back-edge): the longest simple path is b + a.
+        # The previous implementation returned the cache-poisoned (10, [b]) here,
+        # because computing a first cached b without a on the path.
+        expected = (11, [self.b, self.a])
         actual = self.h.deepest_callee_tree(self.b)
         self.assertEqual(expected, actual)
 
     def test_cycle_3(self):
         self.c[collector.CALLEES].remove(self.d)
+        # Longest simple path through the a<->b / a->c->b cycle is a+b+c = 111
+        # for every entry node; previously b and c returned cache-poisoned 10/110.
         self.assertEqual(111, self.h.deepest_callee_tree(self.a)[0])
-        self.assertEqual(10, self.h.deepest_callee_tree(self.b)[0])
-        self.assertEqual(110, self.h.deepest_callee_tree(self.c)[0])
+        self.assertEqual(111, self.h.deepest_callee_tree(self.b)[0])
+        self.assertEqual(111, self.h.deepest_callee_tree(self.c)[0])
+
+    def test_cycle_order_independent(self):
+        # Same graph as test_cycle_3, but compute b FIRST -- the order that used
+        # to poison the shared cache. Every node must still get the correct value.
+        self.c[collector.CALLEES].remove(self.d)
+        self.assertEqual(111, self.h.deepest_callee_tree(self.b)[0])
+        self.assertEqual(111, self.h.deepest_callee_tree(self.c)[0])
+        self.assertEqual(111, self.h.deepest_callee_tree(self.a)[0])
 
     def test_caller(self):
         self.d[collector.CALLERS] = []

--- a/tests/test_backtrace_helper.py
+++ b/tests/test_backtrace_helper.py
@@ -131,3 +131,51 @@ class TestBacktraceHelperTreeSizes(unittest.TestCase):
     def test_caller_cycle(self):
         self.assertEqual(1111, self.h.deepest_caller_tree(self.f)[0])
         self.assertEqual(11111, self.h.deepest_caller_tree(self.e)[0])
+
+    def test_recursion_flag_mutual(self):
+        cc = collector.Collector(None)
+        x = cc.add_symbol("x", "10", type=collector.TYPE_FUNCTION, stack_size=1)
+        y = cc.add_symbol("y", "20", type=collector.TYPE_FUNCTION, stack_size=1)
+        z = cc.add_symbol("z", "30", type=collector.TYPE_FUNCTION, stack_size=1)
+        cc.enhance_call_tree()
+        cc.add_function_call(x, y)
+        cc.add_function_call(y, x)  # x <-> y mutual recursion; z is independent
+        h = BacktraceHelper(cc)
+        for fn in (x, y, z):
+            h.deepest_callee_tree(fn)
+            h.deepest_caller_tree(fn)
+        h.annotate_call_tree_flags()
+        self.assertTrue(x.get(collector.RECURSION_IN_CALL_TREE))
+        self.assertTrue(y.get(collector.RECURSION_IN_CALL_TREE))
+        self.assertFalse(z.get(collector.RECURSION_IN_CALL_TREE))
+
+    def test_recursion_flag_direct(self):
+        cc = collector.Collector(None)
+        r = cc.add_symbol("r", "40", type=collector.TYPE_FUNCTION, stack_size=1)
+        s = cc.add_symbol("s", "50", type=collector.TYPE_FUNCTION, stack_size=1)
+        cc.enhance_call_tree()
+        cc.add_function_call(r, r)  # direct self-recursion
+        cc.add_function_call(s, r)  # s -> r reaches the recursive r
+        h = BacktraceHelper(cc)
+        for fn in (r, s):
+            h.deepest_callee_tree(fn)
+            h.deepest_caller_tree(fn)
+        h.annotate_call_tree_flags()
+        self.assertTrue(r.get(collector.RECURSION_IN_CALL_TREE))
+        self.assertTrue(s.get(collector.RECURSION_IN_CALL_TREE))
+
+    def test_warning_flags_are_transitive(self):
+        # a -> b -> d, where d (deep in a's tree) performs an indirect call.
+        # The flag must reach a, not only d's direct parent b (F7).
+        cc = collector.Collector(None)
+        a = cc.add_symbol("a", "10", type=collector.TYPE_FUNCTION, stack_size=1)
+        b = cc.add_symbol("b", "20", type=collector.TYPE_FUNCTION, stack_size=1)
+        d = cc.add_symbol("d", "30", type=collector.TYPE_FUNCTION, stack_size=1)
+        d[collector.PERFORMS_INDIRECT_CALL] = True
+        cc.enhance_call_tree()
+        cc.add_function_call(a, b)
+        cc.add_function_call(b, d)
+        h = BacktraceHelper(cc)
+        h.annotate_call_tree_flags()
+        self.assertEqual(1, a.get(collector.UNRESOLVED_CALLS_IN_CALL_TREE))
+        self.assertEqual(1, b.get(collector.UNRESOLVED_CALLS_IN_CALL_TREE))

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -456,6 +456,17 @@ $t():
         self.assertEqual([], data["functions"])
         self.assertEqual([], data["variables"])
 
+    def test_self_recursion_sets_flag(self):
+        # A direct self-call records SELF_RECURSIVE but still adds no self-edge,
+        # so the recursion is not lost silently (F5).
+        c = Collector(None)
+        f = c.add_symbol("f", "0x10", type=collector.TYPE_FUNCTION, stack_size=8)
+        c.enhance_call_tree()
+        c.add_function_call(f, f)
+        self.assertTrue(f.get(collector.SELF_RECURSIVE))
+        self.assertEqual([], f[collector.CALLEES])
+        self.assertEqual([], f[collector.CALLERS])
+
     def test_enhance_function_size_from_assembly(self):
         c = Collector(None)
         c.symbols = {

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -434,6 +434,28 @@ $t():
         )
         self.assertEqual(4, c.count_assembly_code_bytes("878:	000001ba 	.word	0x000001ba"))
 
+    def test_report_stack_skips_non_function_symbols(self):
+        # A variable whose display_name matches a requested name must not crash
+        # (variables have no deepest_*_tree). Regression test for F3.
+        c = Collector(None)
+        v = c.add_symbol("myvar", "0x1000", size=4, type=collector.TYPE_VARIABLE)
+        v[collector.DISPLAY_NAME] = "myvar"
+        result = c.report_max_static_stack_usages_from_function_names(["myvar"], "json")
+        self.assertEqual({}, result)
+
+    def test_json_export_skips_typeless_symbol(self):
+        # A symbol with no TYPE (nm letter not in our map) must be skipped, not
+        # crash the whole report. Regression test for F4.
+        c = Collector(None)
+        s = c.add_symbol("foo", "0x2000", size=4)  # no type, no asm -> TYPE never set
+        s[collector.DISPLAY_NAME] = "foo"
+        self.assertNotIn(collector.TYPE, s)
+        c.build_symbol_name_index()
+        data = {}
+        c.prepare_report_for_json_export(data)  # must not raise
+        self.assertEqual([], data["functions"])
+        self.assertEqual([], data["variables"])
+
     def test_enhance_function_size_from_assembly(self):
         c = Collector(None)
         c.symbols = {

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -194,6 +194,23 @@ class TestRenderer(unittest.TestCase):
                         actual = c.url_for("/")
                         self.assertEqual("/?foo=bar", actual)
 
+    def test_url_for_symbol_guards_none_and_typeless(self):
+        """url_for_symbol must not raise on None (breadcrumb folder at the root
+        of --src_root) or on a symbol without a TYPE. Regression test for the
+        renderer HTTP 500."""
+        from flask import Flask
+
+        app = Flask(__name__)
+        with app.test_request_context():
+            c = Mock()
+            c.root_folders = Mock(return_value=[])
+            c.all_symbols = Mock(return_value=[])
+            c.all_functions = Mock(return_value=[])
+            c.all_variables = Mock(return_value=[])
+            r = renderers.HTMLRenderer(c)
+            self.assertEqual("", r.url_for_symbol(None))
+            self.assertEqual("", r.url_for_symbol({}))  # no TYPE, no PATH
+
     def test_none_sum_empty_list(self):
         """Test that none_sum returns None for an empty list"""
         self.assertIsNone(renderers.none_sum([]))


### PR DESCRIPTION
## Summary

Six small, independent correctness fixes to puncover's call-graph / worst-case-stack analysis:
three crashes on otherwise-valid input, a wrong worst-case-stack number on recursive call graphs,
and two warning-honesty improvements. Each change is local and backwards-compatible — behaviour is
unchanged for inputs that already worked — and each comes with a regression test. The full suite
(104 tests) passes, and `ruff check --select I`, `ruff format` and `ruff check` are clean.

The work is in **two commits** along a clean line, so it can be reviewed commit-by-commit (or split
into two PRs if you prefer):

1. **Fix crashes and incorrect worst-case stack on cyclic call graphs**
2. **Warn about recursion and make call-tree warnings transitive**

---

## Commit 1 — Fix crashes and incorrect worst-case stack on cyclic call graphs

### `renderers.py` — `url_for_symbol` returns HTTP 500 on valid input
`url_for_symbol` indexes `value[collector.TYPE]`, which raises in two reachable cases:
- **`TypeError`** when `value` is `None`: the breadcrumb passes `folder=None` for a source file at
  the root of `--src_root` (`file.html.jinja`, `symbol.html.jinja`).
- **`KeyError`** when a symbol has no `type` (an `nm` type letter not in the map), reached via the
  assembly filter, which links any `<symbol>` in the disassembly.

Fix: return `""` when `value is None`, and read `value.get(collector.TYPE)` so a type-less symbol
falls through to the existing file/folder branch. No change for symbols that have a type.

### `collector.py` — stack report crashes when a requested name is a variable
`report_max_static_stack_usages_from_function_names` iterates **all** symbols and, on a name match,
reads `sym["deepest_callee_tree"]`. Variables have no call tree, so a
`--report-max-static-stack-usage NAME` that matches a variable's display name raises `KeyError` and
aborts the report. Fix: skip non-function symbols.

### `collector.py` — JSON export crashes on a type-less symbol
`prepare_report_for_json_export` indexes `non_circular_sym["type"]`, raising `KeyError` and aborting
the whole `--generate-report` whenever a symbol lacks a `type` — e.g. small-data (`g`/`s`) or common
(`C`) symbols, whose `nm` letters aren't in the type map. Fix: classify with `.pop("type", None)`
and skip symbols that are neither function nor variable.

### `backtrace_helper.py` — worst-case stack is wrong on cyclic call graphs
`deepest_call_tree` memoises **every** result while ignoring the `visited` path used to break
cycles. With cycles (mutual recursion) the value cached for a node depends on which start node
expanded it first, so the worst-case stack comes out **order-dependent and under-counted** — about
**10× too low** in a small reproducer. Fix: cache only results that did **not** have to break a
cycle (`hit_cycle`); cycle-involved nodes are recomputed, giving the correct, order-independent
longest *simple* path. Acyclic graphs are unchanged (still cached). The warning-flag bookkeeping is
moved into a separate `annotate_call_tree_flags` pass so the recomputation cannot double-count it.

*Test note:* this updates the expected values of two **existing** tests in
`tests/test_backtrace_helper.py` (`test_cycle_2`, `test_cycle_3`) — they asserted the buggy,
cache-dependent numbers and now assert the correct, order-independent ones (the code is fixed and
the expectations corrected, not relaxed to pass). A new `test_cycle_order_independent` checks the
cyclic nodes in the order that used to corrupt the cache.

---

## Commit 2 — Warn about recursion and make call-tree warnings transitive

These touch only the warnings on the "worst-case stack" page; no stack figure changes.

### Warn when the call tree contains recursion
A recursive call tree can't have its stack bounded statically, yet the page showed a finite
worst-case figure with no hint that it is only a lower bound. Two cases were silent: direct
recursion (a self-call is dropped in `add_function_call`, so a self-recursive function reported a
single frame) and mutual recursion (cycles were broken silently). Fix: record `self_recursive` on a
direct self-call; a memoised, path-independent "reaches a cycle" check (`_reaches_recursion`) sets
`recursion_in_call_tree` for any function whose callee- or caller-tree contains direct or mutual
recursion; `symbol.html.jinja` shows a warning that the figure is a lower bound.

### Make the `*_in_call_tree` warnings transitive
The "unresolved indirect call / missing stack size / dynamic stack" counters were named
`*_in_call_tree` but only counted a function's **direct** callees/callers, so a problem deep in the
tree warned only its immediate parent. Fix: count over the **whole** tree — the deduplicated union
of everything reachable via callees and via callers (`_reachable`, an iterative cycle-safe BFS) — so
a problem anywhere warns every ancestor. (The BFS is cheap for the sparse, shallow call graphs
puncover analyses.)

---

Happy to split this into two separate PRs (one per commit) if you'd prefer smaller reviews.
