### PR TITLE
Add option for using a indirect callees file

### DIFF
--- a/puncover/builders.py
+++ b/puncover/builders.py
@@ -7,11 +7,12 @@ from puncover.backtrace_helper import BacktraceHelper
 
 
 class Builder:
-    def __init__(self, collector, src_root):
+    def __init__(self, collector, src_root, indirect_callees_file=None):
         self.files = {}
         self.collector = collector
         self.backtrace_helper = BacktraceHelper(collector)
         self.src_root = pathlib.Path(src_root)
+        self.indirect_callees_file = indirect_callees_file
 
     def store_file_time(self, path, store_empty=False):
         self.files[path] = 0 if store_empty else os.path.getmtime(path)
@@ -23,6 +24,8 @@ class Builder:
         self.collector.parse_elf(self.get_elf_path())
         self.collector.enhance(self.src_root)
         self.collector.parse_su_dir(self.get_su_dir())
+        if self.indirect_callees_file:
+            self.collector.add_indirect_callees_from_file(self.indirect_callees_file)
         self.build_call_trees()
 
     def needs_build(self):
@@ -47,8 +50,13 @@ class Builder:
 
 
 class ElfBuilder(Builder):
-    def __init__(self, collector, src_root, elf_file, su_dir):
-        Builder.__init__(self, collector, src_root if src_root else dirname(dirname(elf_file)))
+    def __init__(self, collector, src_root, elf_file, su_dir, indirect_callees_file=None):
+        Builder.__init__(
+            self,
+            collector,
+            src_root if src_root else dirname(dirname(elf_file)),
+            indirect_callees_file=indirect_callees_file,
+        )
         self.store_file_time(elf_file, store_empty=True)
         self.elf_file = pathlib.Path(elf_file)
         self.su_dir = su_dir

--- a/puncover/collector.py
+++ b/puncover/collector.py
@@ -785,6 +785,79 @@ class Collector:
         self.user_defined_stack_report = report_max_map
         return report_max_map
 
+    def add_indirect_callees_from_file(self, filepath):
+        """Add indirect callee edges to the call graph from a JSON file.
+
+        This method lets external tools pre-compute caller→callee relationships that puncover
+        cannot discover from assembly alone (typically because they go through function pointers.
+        The JSON file is produced by those tools and consumed here in a toolchain-agnostic way.        
+
+        **File format** (``version: 1``)::
+
+            {
+              "version": 1,
+              "indirect_callees": [
+                {
+                  "caller": "function_using_callback_pointers",
+                  "callees": ["callback_1", "callback_2"]
+                }
+              ]
+            }
+
+        ``caller`` and each name in ``callees`` must be raw C symbol names as
+        they appear in ``nm`` output (i.e. not C++ demangled).
+
+        This method must be called **after** :py:meth:`enhance` (so that
+        ``CALLEES`` / ``CALLERS`` lists exist on every function symbol) and
+        **before** the call-tree depth computation in
+        :py:class:`~puncover.builders.Builder`.
+
+        The ``PERFORMS_INDIRECT_CALL`` flag is intentionally left unchanged on
+        the caller – there may be additional unresolved indirect calls in the
+        same function that are not covered by this file.
+
+        Args:
+            filepath: path to the JSON indirect-callees file
+        """
+        import json as _json
+
+        self.build_symbol_name_index()
+
+        with open(filepath) as f:
+            data = _json.load(f)
+
+        for entry in data.get("indirect_callees", []):
+            caller_name = entry.get("caller")
+            callee_names = entry.get("callees", [])
+
+            if not caller_name:
+                warning("indirect callees file: entry missing 'caller' field, skipping")
+                continue
+
+            caller = self.symbol(caller_name, qualified=False)
+            if not caller:
+                warning(
+                    f"indirect callees file: caller '{caller_name}' not found in symbol table"
+                )
+                continue
+
+            resolved = 0
+            for callee_name in callee_names:
+                callee = self.symbol(callee_name, qualified=False)
+                if not callee:
+                    warning(
+                        f"indirect callees file: callee '{callee_name}' not found "
+                        f"in symbol table (caller: '{caller_name}')"
+                    )
+                    continue
+                self.add_function_call(caller, callee)
+                resolved += 1
+
+            print(
+                f"Added {resolved}/{len(callee_names)} indirect callee(s) "
+                f"for '{caller_name}' from {filepath}"
+            )
+
     def prepare_report_for_json_export(self, export_json_data):
         fn_symbols = []
         var_symbols = []

--- a/puncover/puncover.py
+++ b/puncover/puncover.py
@@ -36,10 +36,10 @@ def get_default_port():
     return DEFAULT_PORT if not is_port_in_use(DEFAULT_PORT) else DEFAULT_PORT_FALLBACK
 
 
-def create_builder(gcc_base_filename, elf_file=None, su_dir=None, src_root=None):
+def create_builder(gcc_base_filename, elf_file=None, su_dir=None, src_root=None, indirect_callees_file=None):
     c = Collector(GCCTools(gcc_base_filename))
     if elf_file:
-        return ElfBuilder(c, src_root, elf_file, su_dir)
+        return ElfBuilder(c, src_root, elf_file, su_dir, indirect_callees_file=indirect_callees_file)
     else:
         raise Exception("Unable to configure builder for collector")
 
@@ -156,6 +156,17 @@ def main():
     )
     parser.add_argument("--version", action="version", version="%(prog)s " + version)
     parser.add_argument(
+        "--add-indirect-callees-file",
+        "--add_indirect_callees_file",
+        dest="add_indirect_callees_file",
+        metavar="FILE",
+        help=(
+            "JSON file listing indirect caller/callee relationships to inject into the "
+            "call graph before computing stack depths.  Produced by external tools. "
+            'Format: {"version": 1, "indirect_callees": [{"caller": "fn", "callees": ["callee1", ...]}]}'
+        ),
+    )
+    parser.add_argument(
         "--report-schema",
         action="store_true",
         help="print the JSON schema for the report output and exit",
@@ -180,7 +191,11 @@ def main():
         exit(1)
 
     builder = create_builder(
-        args.gcc_tools_base, elf_file=elf_file, src_root=args.src_root, su_dir=args.build_dir
+        args.gcc_tools_base,
+        elf_file=elf_file,
+        src_root=args.src_root,
+        su_dir=args.build_dir,
+        indirect_callees_file=args.add_indirect_callees_file,
     )
     builder.build_if_needed()
 

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -280,6 +280,58 @@ class TestArguments(unittest.TestCase):
             self.assertEqual(run_kwargs["host"], "0.0.0.0")
             self.assertEqual(run_kwargs["port"], 5000)
 
+    def test_add_indirect_callees_file_hyphen_format(self):
+        """Test that --add-indirect-callees-file argument works (hyphen format)."""
+        test_args = [
+            "puncover",
+            "--gcc_tools_base",
+            "/path/to/gcc",
+            "--elf_file",
+            "/path/to/file.elf",
+            "--add-indirect-callees-file",
+            "/path/to/callees.json",
+        ]
+
+        with self._patched_main(test_args) as env:
+            main()
+            env.create_builder.assert_called_once()
+            call_args = env.create_builder.call_args
+            self.assertEqual(call_args[1]["indirect_callees_file"], "/path/to/callees.json")
+
+    def test_add_indirect_callees_file_underscore_format(self):
+        """Test that --add_indirect_callees_file argument works (underscore format)."""
+        test_args = [
+            "puncover",
+            "--gcc_tools_base",
+            "/path/to/gcc",
+            "--elf_file",
+            "/path/to/file.elf",
+            "--add_indirect_callees_file",
+            "/path/to/callees.json",
+        ]
+
+        with self._patched_main(test_args) as env:
+            main()
+            env.create_builder.assert_called_once()
+            call_args = env.create_builder.call_args
+            self.assertEqual(call_args[1]["indirect_callees_file"], "/path/to/callees.json")
+
+    def test_add_indirect_callees_file_defaults_to_none(self):
+        """Test that --add-indirect-callees-file defaults to None when not specified."""
+        test_args = [
+            "puncover",
+            "--gcc_tools_base",
+            "/path/to/gcc",
+            "--elf_file",
+            "/path/to/file.elf",
+        ]
+
+        with self._patched_main(test_args) as env:
+            main()
+            env.create_builder.assert_called_once()
+            call_args = env.create_builder.call_args
+            self.assertIsNone(call_args[1]["indirect_callees_file"])
+
 
 class TestConfigFile(unittest.TestCase):
     def _create_mock_environment(self):

--- a/tests/test_collector_indirect_callees.py
+++ b/tests/test_collector_indirect_callees.py
@@ -1,0 +1,199 @@
+import json
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from puncover.collector import (
+    CALLEES,
+    CALLERS,
+    TYPE,
+    TYPE_FUNCTION,
+    Collector,
+)
+
+
+def _make_collector_with_functions(*name_addr_pairs):
+    """Return a Collector pre-populated with function symbols that have empty
+    CALLEES/CALLERS lists (mimicking post-enhance_call_tree state)."""
+    c = Collector(None)
+    for name, addr in name_addr_pairs:
+        sym = c.add_symbol(name, addr, type=TYPE_FUNCTION)
+        sym[CALLEES] = []
+        sym[CALLERS] = []
+    c.build_symbol_name_index()
+    return c
+
+
+def _write_json(data):
+    """Write *data* to a temp file and return its path (caller must delete)."""
+    f = tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False)
+    json.dump(data, f)
+    f.close()
+    return f.name
+
+
+class TestAddIndirectCalleesFromFile(unittest.TestCase):
+
+    def test_adds_callee_edges_for_known_symbols(self):
+        c = _make_collector_with_functions(
+            ("caller_func", "0x1000"),
+            ("callee_one",  "0x2000"),
+            ("callee_two",  "0x3000"),
+        )
+        caller  = c.symbol("caller_func",  qualified=False)
+        callee1 = c.symbol("callee_one",   qualified=False)
+        callee2 = c.symbol("callee_two",   qualified=False)
+
+        tmp = _write_json({
+            "version": 1,
+            "indirect_callees": [
+                {"caller": "caller_func", "callees": ["callee_one", "callee_two"]}
+            ],
+        })
+        try:
+            c.add_indirect_callees_from_file(tmp)
+        finally:
+            os.unlink(tmp)
+
+        self.assertIn(callee1, caller[CALLEES])
+        self.assertIn(callee2, caller[CALLEES])
+        self.assertIn(caller, callee1[CALLERS])
+        self.assertIn(caller, callee2[CALLERS])
+
+    def test_multiple_caller_entries(self):
+        c = _make_collector_with_functions(
+            ("dispatcher_a", "0x1000"),
+            ("dispatcher_b", "0x1100"),
+            ("handler_x",    "0x2000"),
+            ("handler_y",    "0x2100"),
+            ("handler_z",    "0x2200"),
+        )
+        tmp = _write_json({
+            "version": 1,
+            "indirect_callees": [
+                {"caller": "dispatcher_a", "callees": ["handler_x", "handler_y"]},
+                {"caller": "dispatcher_b", "callees": ["handler_z"]},
+            ],
+        })
+        try:
+            c.add_indirect_callees_from_file(tmp)
+        finally:
+            os.unlink(tmp)
+
+        da = c.symbol("dispatcher_a", qualified=False)
+        db = c.symbol("dispatcher_b", qualified=False)
+        hx = c.symbol("handler_x",    qualified=False)
+        hy = c.symbol("handler_y",    qualified=False)
+        hz = c.symbol("handler_z",    qualified=False)
+
+        self.assertIn(hx, da[CALLEES])
+        self.assertIn(hy, da[CALLEES])
+        self.assertIn(hz, db[CALLEES])
+        self.assertNotIn(hz, da[CALLEES])
+
+    def test_does_not_add_duplicate_edges(self):
+        c = _make_collector_with_functions(
+            ("caller_func", "0x1000"),
+            ("callee_one",  "0x2000"),
+        )
+        caller  = c.symbol("caller_func", qualified=False)
+        callee1 = c.symbol("callee_one",  qualified=False)
+
+        data = {
+            "version": 1,
+            "indirect_callees": [
+                {"caller": "caller_func", "callees": ["callee_one"]}
+            ],
+        }
+        tmp = _write_json(data)
+        try:
+            c.add_indirect_callees_from_file(tmp)
+            c.add_indirect_callees_from_file(tmp)  # call twice
+        finally:
+            os.unlink(tmp)
+
+        self.assertEqual(caller[CALLEES].count(callee1), 1)
+        self.assertEqual(callee1[CALLERS].count(caller), 1)
+
+    def test_warns_on_unknown_caller(self):
+        c = _make_collector_with_functions(
+            ("callee_one", "0x2000"),
+        )
+        tmp = _write_json({
+            "version": 1,
+            "indirect_callees": [
+                {"caller": "no_such_function", "callees": ["callee_one"]}
+            ],
+        })
+        try:
+            with patch("puncover.collector.warning") as mock_warn:
+                c.add_indirect_callees_from_file(tmp)
+                mock_warn.assert_called_once()
+                self.assertIn("no_such_function", mock_warn.call_args[0][0])
+        finally:
+            os.unlink(tmp)
+
+    def test_warns_on_unknown_callee(self):
+        c = _make_collector_with_functions(
+            ("caller_func", "0x1000"),
+        )
+        tmp = _write_json({
+            "version": 1,
+            "indirect_callees": [
+                {"caller": "caller_func", "callees": ["no_such_callee"]}
+            ],
+        })
+        try:
+            with patch("puncover.collector.warning") as mock_warn:
+                c.add_indirect_callees_from_file(tmp)
+                mock_warn.assert_called_once()
+                self.assertIn("no_such_callee", mock_warn.call_args[0][0])
+        finally:
+            os.unlink(tmp)
+
+    def test_skips_entry_missing_caller_field(self):
+        c = _make_collector_with_functions(
+            ("callee_one", "0x2000"),
+        )
+        tmp = _write_json({
+            "version": 1,
+            "indirect_callees": [
+                {"callees": ["callee_one"]}   # no "caller" key
+            ],
+        })
+        try:
+            with patch("puncover.collector.warning") as mock_warn:
+                c.add_indirect_callees_from_file(tmp)
+                mock_warn.assert_called_once()
+        finally:
+            os.unlink(tmp)
+
+    def test_empty_indirect_callees_list(self):
+        c = _make_collector_with_functions(
+            ("caller_func", "0x1000"),
+        )
+        tmp = _write_json({"version": 1, "indirect_callees": []})
+        try:
+            # should not raise, not warn
+            with patch("puncover.collector.warning") as mock_warn:
+                c.add_indirect_callees_from_file(tmp)
+                mock_warn.assert_not_called()
+        finally:
+            os.unlink(tmp)
+
+    def test_missing_indirect_callees_key(self):
+        c = _make_collector_with_functions(
+            ("caller_func", "0x1000"),
+        )
+        tmp = _write_json({"version": 1})
+        try:
+            with patch("puncover.collector.warning") as mock_warn:
+                c.add_indirect_callees_from_file(tmp)
+                mock_warn.assert_not_called()
+        finally:
+            os.unlink(tmp)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The file would be a standard format for adding callees to a specific caller. This is useful for cases where puncover cannot find indirect callees, but where the user knows a way to find them, and can generate a list of them. The user one use a project or platform specific tool to generate the list which can now be passed to puncover as a argument and added to analysis.