### PR TITLE
Name normalization for isra symbols

### DIFF
--- a/puncover/collector.py
+++ b/puncover/collector.py
@@ -131,8 +131,9 @@ class Collector:
         int_address = int(address, 16)
         sym = self.symbols.get(int_address, {})
         if NAME in sym and sym[NAME] != name:
-            # warning("Name for symbol at %s inconsistent (was '%s', now '%s')" % (address, sym[NAME], name))
-            pass
+            # prefer the more specific variant (e.g. foo.isra.0 over foo)
+            if name.startswith(sym[NAME] + ".") and len(name) > len(sym[NAME]):
+                sym[NAME] = name
         else:
             sym[NAME] = name
         if size:
@@ -160,11 +161,11 @@ class Collector:
     # 00000550 00000034 T main	/Users/behrens/Documents/projects/pebble/puncover/puncover/build/../src/puncover.c:25
     if os.name == "nt":
         parse_size_line_re = re.compile(
-            r"^([\da-f]{8,16})\s+([\da-f]{8,16})\s+(.)\s+(\w+)(\s+([a-zA-Z]:.+)):(\d+)?"
+            r"^([\da-f]{8,16})\s+([\da-f]{8,16})\s+(.)\s+([^\s]+)(\s+([a-zA-Z]:.+)):(\d+)?"
         )
     else:
         parse_size_line_re = re.compile(
-            r"^([\da-f]{8,16})\s+([\da-f]{8,16})\s+(.)\s+(\w+)(\s+([^:]+):(\d+))?"
+            r"^([\da-f]{8,16})\s+([\da-f]{8,16})\s+(.)\s+([^\s]+)(\s+([^:]+):(\d+))?"
         )
 
     def parse_size_line(self, line):
@@ -336,6 +337,18 @@ class Collector:
             return False
 
         if a == b:
+            return True
+
+        def normalize_gcc_suffix(name):
+            return re.sub(
+                r"\.(isra|constprop|part|clone)\.\d+$",
+                lambda m: "." + m.group(1),
+                name,
+            )
+
+        normalized_a = normalize_gcc_suffix(a)
+        normalized_b = normalize_gcc_suffix(b)
+        if normalized_a == normalized_b:
             return True
 
         simplified_a = self.display_name_simplified(a)

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -85,6 +85,21 @@ class TestCollector(unittest.TestCase):
             },
         )
 
+    def test_parses_function_line_with_gcc_suffix(self):
+        c = Collector(None)
+        file_path = "/tmp/puncover.c"
+        if os.name == "nt":
+            file_path = "C:\\tmp\\puncover.c"
+        line = "00000100 00000010 T foo.isra.0 " + file_path + ":1"
+        self.assertTrue(c.parse_size_line(line))
+        self.assertEqual("foo.isra.0", c.symbols[0x00000100]["name"])
+
+    def test_prefers_more_specific_symbol_name_for_same_address(self):
+        c = Collector(None)
+        c.add_symbol("foo", "00000100")
+        c.add_symbol("foo.isra.0", "00000100")
+        self.assertEqual("foo.isra.0", c.symbols[0x00000100]["name"])
+
     def test_ignores_incomplete_size_line_1(self):
         c = Collector(None)
         line = "0000059c D __dso_handle"
@@ -424,6 +439,8 @@ $t():
             )
         )
         self.assertTrue(f("bool SDCardTask::isLogging() const", "SDCardTask::isLogging() const"))
+        self.assertTrue(f("foo.isra", "foo.isra.0"))
+        self.assertTrue(f("foo.constprop", "foo.constprop.12"))
 
     def test_count_bytes(self):
         c = Collector(None)


### PR DESCRIPTION
During optimization GCC can create a clone of the original function, with optimized functionality. These get appended with .isra.<number> In some cases the su files do not get the .<number> appended to the name. This causes an issue where pun cover cant correlate the the su file and the elf file data for a symbol.

Fix:
Parse dotted symbol names from nm.
Use more specific symbol names at same address (e.g. keep foo.isra.0 over foo), Treat GCC clone suffix variants as equivalent in stack-name matching (oo.isra == foo.isra.0)