### PR TITLE
Add command line visual preview of stack usages

### DIFF
--- a/puncover/collector.py
+++ b/puncover/collector.py
@@ -841,7 +841,8 @@ class Collector:
                     # todo nothing?
                     pass
                 else:
-                    print("unknown key " + sym_ele)
+                    pass
+                    # print("unknown key " + sym_ele)
             # add flatten symbol to list
             symbols = fn_symbols if non_circular_sym["type"] == "function" else var_symbols
             non_circular_sym.pop("type")
@@ -849,3 +850,19 @@ class Collector:
         # if file exist
         export_json_data["functions"] = fn_symbols
         export_json_data["variables"] = var_symbols
+
+    def print_stack_size_report(self):
+        print("┌" + 73 * "─" + "┐")
+        for function_name in self.user_defined_stack_report:
+            stack_report = self.user_defined_stack_report[function_name]
+            worst_stack_size = stack_report["max_static_stack_size"]
+            max_static_stack_size = stack_report["max_stack_size"]
+            stack_use_percent = worst_stack_size / max_static_stack_size * 100
+            progressbar_20_full = int(stack_use_percent / 100.0 * 20)
+            progressbar_20_empty = 20 - progressbar_20_full
+            # │ log_process_thread_func   - 100.0% - 11111/22222 - │███████████████-----│
+            print(
+                f"│ {function_name:<25} - {f'{stack_use_percent:.1f}':>5}% - {worst_stack_size:>5}"
+                f"/{max_static_stack_size:>5}b - {progressbar_20_full * '█'}{progressbar_20_empty * '-'}│"
+            )
+        print("└" + 73 * "─" + "┘")

--- a/puncover/puncover.py
+++ b/puncover/puncover.py
@@ -126,6 +126,12 @@ def main():
         help="generate a JSON report file",
     )
     parser.add_argument(
+        "--print-stack-size-report",
+        "--print_stack_size_report",
+        action="store_true",
+        help="print the the found worst case stack usage for each funtion given by --report-max-static-stack-usage",
+    )
+    parser.add_argument(
         "--report-type",
         "--report_type",
         default="json",
@@ -198,6 +204,8 @@ def main():
                     args.report_max_static_stack_usage, args.report_type
                 )
             )
+            builder.collector.print_stack_size_report()
+            # if args.print_stack_size_report:
         builder.collector.prepare_report_for_json_export(tag_data)
         export_json[args.report_tag] = tag_data
         with open(args.report_filename + ".json", "w") as f:


### PR DESCRIPTION
When I build firmware I like to see the `size` output.
Similarly I thought a preview of the found worst stack usage would be cool :)
Adding an option `--print_stack_size_report` to do so.
Here an example of zepyhr mqtt-publisher sample on the SAME70:

```bash
┌─────────────────────────────────────────────────────────────────────────┐
│ log_process_thread_func   -  42.3% -   352/  832b - ████████------------│
│ shell_thread              -   7.3% -   304/ 4160b - █-------------------│
│ mgmt_event_work_handler   -  31.2% -   280/  896b - ██████--------------│
│ bg_thread_main            -  58.3% -  1232/ 2112b - ███████████---------│
│ work_queue_main           -  25.0% -   272/ 1088b - █████---------------│
└─────────────────────────────────────────────────────────────────────────┘
```

the puncover config used is

```yaml
elf_file: ~/zephyrproject/zephyr/samples/net/mqtt_publisher/build/zephyr/zephyr.elf
gcc-tools-base: ~/zephyr-sdk-1.0.1/gnu/arm-zephyr-eabi/bin/arm-zephyr-eabi-
src_root: ~/zephyrproject/zephyr
build_dir: ~/zephyrproject/zephyr/samples/net/mqtt_publisher/build
generate-report: true
non-interactive: true
report-type: json 
print-stack-size-report: true
report-max-static-stack-usage: 
  log_process_thread_func:::832
  - shell_thread:::4160
  - bg_thread_main:::2112
  - work_queue_main:::1088
  - mgmt_event_work_handler:::896
```

I am still thinking about what to print in a warning case when the stack is near full or an overflow is detected and how to print the stacktrace...